### PR TITLE
Adding 6 as a valid option for the manual feed

### DIFF
--- a/custom_components/petkit/text.py
+++ b/custom_components/petkit/text.py
@@ -176,7 +176,7 @@ class PetkitText(PetkitEntity, TextEntity):
             valid_values = list(range(5, 201))
         else:
             # Other, D4sh => 1,2,3,4,5,7,8,9,10
-            valid_values = [1, 2, 3, 4, 5, 7, 8, 9, 10]
+            valid_values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
         if int(value) not in valid_values:
             raise ValueError(


### PR DESCRIPTION
The number 6 is not a valid option when Manual feed hooper is used. I added the number 6 to the array of valid options.