### PR TITLE
Fix French translation for desiccant

### DIFF
--- a/custom_components/petkit/translations/fr.json
+++ b/custom_components/petkit/translations/fr.json
@@ -121,7 +121,7 @@
         "name": "Nourriture r\u00e9approvisionn\u00e9e"
       },
       "reset_desiccant": {
-        "name": "R\u00e9initialiser dessiccant"
+        "name": "R\u00e9initialiser déshydratant"
       },
       "reset_odor_eliminator": {
         "name": "R\u00e9initialiser \u00e9liminateur d'odeurs"
@@ -209,7 +209,7 @@
         "name": "Niveau d\u00e9sodorisant"
       },
       "desiccant_left_days": {
-        "name": "Jours restants dessiccant"
+        "name": "Jours restants déshydratant"
       },
       "device_status": {
         "name": "\u00c9tat de l'appareil"
@@ -454,7 +454,7 @@
         "name": "Notif. remplacement d\u00e9sodorisant"
       },
       "desiccant_notif": {
-        "name": "Notif. changement dessiccant"
+        "name": "Notif. changement déshydratant"
       },
       "dispensing_notif": {
         "name": "Notif. distribution"


### PR DESCRIPTION
I think "déshydratant" is a better translation :-) This is also what's used on Amazon:

<img width="307" alt="Screenshot 2025-01-27 at 16 54 51" src="https://github.com/user-attachments/assets/42c8ac75-7a20-4c9f-91a6-6f5a0ff8119c" />
