### PR TITLE
Fix switch actions for Fresh Element Mini

### DIFF
--- a/custom_components/petkit/manifest.json
+++ b/custom_components/petkit/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/Jezza34000/homeassistant_petkit/issues",
   "loggers": ["petkit"],
   "requirements": ["pypetkitapi==1.11.2", "aiofiles==24.1.0"],
-  "version": "0.1.0"
+  "version": "1.6.4"
 }

--- a/custom_components/petkit/manifest.json
+++ b/custom_components/petkit/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/Jezza34000/homeassistant_petkit/issues",
   "loggers": ["petkit"],
   "requirements": ["pypetkitapi==1.11.2", "aiofiles==24.1.0"],
-  "version": "1.6.4"
+  "version": "0.1.0"
 }

--- a/custom_components/petkit/switch.py
+++ b/custom_components/petkit/switch.py
@@ -93,6 +93,20 @@ COMMON_ENTITIES = [
         turn_off=lambda api, device: api.send_api_request(
             device.id, DeviceCommand.UPDATE_SETTING, {"manualLock": 0}
         ),
+        ignore_types=FEEDER_MINI,
+    ),
+    PetKitSwitchDesc(
+        key="Child lock",
+        translation_key="child_lock",
+        value=lambda device: device.settings.manual_lock,
+        entity_category=EntityCategory.CONFIG,
+        turn_on=lambda api, device: api.send_api_request(
+            device.id, DeviceCommand.UPDATE_SETTING, {"settings.manualLock": 1}
+        ),
+        turn_off=lambda api, device: api.send_api_request(
+            device.id, DeviceCommand.UPDATE_SETTING, {"settings.manualLock": 0}
+        ),
+        only_for_types=FEEDER_MINI,
     ),
     PetKitSwitchDesc(
         key="Camera",

--- a/custom_components/petkit/switch.py
+++ b/custom_components/petkit/switch.py
@@ -281,6 +281,20 @@ SWITCH_MAPPING: dict[type[PetkitDevices], list[PetKitSwitchDesc]] = {
             turn_off=lambda api, device: api.send_api_request(
                 device.id, DeviceCommand.UPDATE_SETTING, {"foodNotify": 0}
             ),
+            ignore_types=FEEDER_MINI,
+        ),
+        PetKitSwitchDesc(
+            key="Refill notif",
+            translation_key="refill_notif",
+            value=lambda device: device.settings.food_notify,
+            entity_category=EntityCategory.CONFIG,
+            turn_on=lambda api, device: api.send_api_request(
+                device.id, DeviceCommand.UPDATE_SETTING, {"settings.foodNotify": 1}
+            ),
+            turn_off=lambda api, device: api.send_api_request(
+                device.id, DeviceCommand.UPDATE_SETTING, {"settings.foodNotify": 0}
+            ),
+            only_for_types=FEEDER_MINI,
         ),
         PetKitSwitchDesc(
             key="Pet visit notif",

--- a/custom_components/petkit/switch.py
+++ b/custom_components/petkit/switch.py
@@ -378,6 +378,20 @@ SWITCH_MAPPING: dict[type[PetkitDevices], list[PetKitSwitchDesc]] = {
             turn_off=lambda api, device: api.send_api_request(
                 device.id, DeviceCommand.UPDATE_SETTING, {"desiccantNotify": 0}
             ),
+            ignore_types=FEEDER_MINI,
+        ),
+        PetKitSwitchDesc(
+            key="Desiccant notif",
+            translation_key="desiccant_notif",
+            value=lambda device: device.settings.desiccant_notify,
+            entity_category=EntityCategory.CONFIG,
+            turn_on=lambda api, device: api.send_api_request(
+                device.id, DeviceCommand.UPDATE_SETTING, {"settings.desiccantNotify": 1}
+            ),
+            turn_off=lambda api, device: api.send_api_request(
+                device.id, DeviceCommand.UPDATE_SETTING, {"settings.desiccantNotify": 0}
+            ),
+            only_for_types=FEEDER_MINI,
         ),
     ],
     Litter: [

--- a/custom_components/petkit/switch.py
+++ b/custom_components/petkit/switch.py
@@ -12,6 +12,7 @@ from pypetkitapi import (
     DeviceAction,
     DeviceCommand,
     Feeder,
+    FEEDER_MINI,
     Litter,
     Pet,
     Purifier,
@@ -53,7 +54,7 @@ COMMON_ENTITIES = [
         turn_off=lambda api, device: api.send_api_request(
             device.id, DeviceCommand.UPDATE_SETTING, {"lightMode": 0}
         ),
-        ignore_types=DEVICES_LITTER_BOX,
+        ignore_types=[*DEVICES_LITTER_BOX, FEEDER_MINI],
     ),
     PetKitSwitchDesc(
         key="Display",
@@ -67,6 +68,19 @@ COMMON_ENTITIES = [
             device.id, DeviceCommand.UPDATE_SETTING, {"lightMode": 0}
         ),
         only_for_types=DEVICES_LITTER_BOX,
+    ),
+    PetKitSwitchDesc(
+        key="Indicator light",
+        translation_key="indicator_light",
+        value=lambda device: device.settings.light_mode,
+        entity_category=EntityCategory.CONFIG,
+        turn_on=lambda api, device: api.send_api_request(
+            device.id, DeviceCommand.UPDATE_SETTING, {"settings.lightMode": 1}
+        ),
+        turn_off=lambda api, device: api.send_api_request(
+            device.id, DeviceCommand.UPDATE_SETTING, {"settings.lightMode": 0}
+        ),
+        only_for_types=FEEDER_MINI,
     ),
     PetKitSwitchDesc(
         key="Child lock",

--- a/custom_components/petkit/switch.py
+++ b/custom_components/petkit/switch.py
@@ -255,6 +255,20 @@ SWITCH_MAPPING: dict[type[PetkitDevices], list[PetKitSwitchDesc]] = {
             turn_off=lambda api, device: api.send_api_request(
                 device.id, DeviceCommand.UPDATE_SETTING, {"feedNotify": 0}
             ),
+            ignore_types=FEEDER_MINI,
+        ),
+        PetKitSwitchDesc(
+            key="Dispensing notif",
+            translation_key="dispensing_notif",
+            value=lambda device: device.settings.feed_notify,
+            entity_category=EntityCategory.CONFIG,
+            turn_on=lambda api, device: api.send_api_request(
+                device.id, DeviceCommand.UPDATE_SETTING, {"settings.feedNotify": 1}
+            ),
+            turn_off=lambda api, device: api.send_api_request(
+                device.id, DeviceCommand.UPDATE_SETTING, {"settings.feedNotify": 0}
+            ),
+            only_for_types=FEEDER_MINI,
         ),
         PetKitSwitchDesc(
             key="Refill notif",


### PR DESCRIPTION
The switches for the Fresh Element Mini (version from 2018) are creating errors.

![image](https://github.com/user-attachments/assets/6cbe1ab9-923a-45de-abf6-1c0615293c09)

```
Enregistreur: homeassistant.components.websocket_api.http.connection
Source: components/websocket_api/commands.py:245
intégration: Home Assistant WebSocket API (documentation, problèmes)
S'est produit pour la première fois: 8 janvier 2025 à 19:58:24 (9 occurrences)
Dernier enregistrement: 09:15:47

[547310633168] Unexpected exception
[547290475552] Unexpected exception
[547371422128] Unexpected exception
[548077137360] Unexpected exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/pypetkitapi/client.py", line 725, in _handle_response
    response.raise_for_status()
    ~~~~~^^
  File "/usr/local/lib/python3.13/site-packages/aiohttp/client_reqrep.py", line 1161, in raise_for_status
    raise ClientResponseError(
    ...<5 lines>...
    )
aiohttp.client_exceptions.ClientResponseError: 404, message='Not Found', url='https://api.eu-pet.com/latest/feedermini/updateSettings'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/commands.py", line 245, in handle_call_service
    response = await hass.services.async_call(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<7 lines>...
    )
    ^
  File "/usr/src/homeassistant/homeassistant/core.py", line 2795, in async_call
    response_data = await coro
                    ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/core.py", line 2838, in _execute_service
    return await target(service_call)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
```