### PR TITLE
Add T6 litter consumables to device diagnostics

### DIFF
--- a/custom_components/petkit/diagnostics.py
+++ b/custom_components/petkit/diagnostics.py
@@ -9,7 +9,6 @@ from pypetkitapi import Litter
 from pypetkitapi.litter_container import StateLitter
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntry


### PR DESCRIPTION
## Summary
- Expand `async_get_device_diagnostics` to include full device state and consumable data
- Litter box diagnostics now show:
  - **Waste bin** (集便仓): box_full, box_state, pack_state, bagging_state
  - **Garbage bag box** (垃圾袋盒): package_sn, package_state with label, install time, used/total counts, thresholds
  - **Package info**: last packing time, last replacement time (from `t6/packageInfo`)
  - **Package list**: total count + recent packing records (from `t6/packageList`)
  - **Purification N60 / Deodorant N50 / Spray**: remaining days and state
  - **Cat litter**: sand status, percent, weight, lack indicators
  - **T7 sand tray**: SN, state, use count, remaining days
- General device info: type, id, sn, firmware, hardware, wifi, errors

## Dependency
> **This PR depends on [Jezza34000/py-petkit-api#47](https://github.com/Jezza34000/py-petkit-api/pull/47)** which adds `PackageInfoResult`, `PackageListResult` models and the `t6/packageInfo` + `t6/packageList` fetch logic to pypetkitapi.
>
> The `package_info` and `package_list` sections in diagnostics will only populate once that library PR is merged and the dependency version is bumped.
> All other diagnostics fields (waste bin state, bag box SN/state, N50/N60 days, sand info, etc.) work with the current library version as they come from `device_detail`.