### PR TITLE
feat: add feeding schedule management with dual-hopper support

### DIFF
--- a/custom_components/petkit/__init__.py
+++ b/custom_components/petkit/__init__.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
-import voluptuous as vol
-
 from pypetkitapi import Feeder, PetKitClient
 from pypetkitapi.command import FeederCommand
+import voluptuous as vol
 
 from homeassistant.const import (
     CONF_PASSWORD,
@@ -89,9 +88,7 @@ FEED_DAY_SCHEMA = vol.Schema(
 SERVICE_SET_FEEDING_SCHEDULE_SCHEMA = vol.Schema(
     {
         vol.Required("device_id"): vol.Coerce(int),
-        vol.Required("feed_daily_list"): vol.All(
-            cv.ensure_list, [FEED_DAY_SCHEMA]
-        ),
+        vol.Required("feed_daily_list"): vol.All(cv.ensure_list, [FEED_DAY_SCHEMA]),
     }
 )
 
@@ -174,9 +171,7 @@ async def _async_handle_set_feeding_schedule(
         len(api_payload),
     )
 
-    await client.send_api_request(
-        device_id, FeederCommand.SAVE_FEED, api_payload
-    )
+    await client.send_api_request(device_id, FeederCommand.SAVE_FEED, api_payload)
 
 
 async def async_setup_entry(

--- a/custom_components/petkit/__init__.py
+++ b/custom_components/petkit/__init__.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
-from pypetkitapi import PetKitClient
+import voluptuous as vol
+
+from pypetkitapi import Feeder, PetKitClient
+from pypetkitapi.command import FeederCommand
 
 from homeassistant.const import (
     CONF_PASSWORD,
@@ -14,7 +17,8 @@ from homeassistant.const import (
     CONF_USERNAME,
     Platform,
 )
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import ServiceCall
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.loader import async_get_loaded_integration
 
@@ -61,6 +65,118 @@ PLATFORMS: list[Platform] = [
     Platform.IMAGE,
     Platform.FAN,
 ]
+
+SERVICE_SET_FEEDING_SCHEDULE = "set_feeding_schedule"
+
+FEED_ITEM_SCHEMA = vol.Schema(
+    {
+        vol.Required("time"): vol.All(int, vol.Range(min=0)),
+        vol.Required("name"): cv.string,
+        vol.Optional("amount", default=0): vol.Coerce(int),
+        vol.Optional("amount1", default=0): vol.Coerce(int),
+        vol.Optional("amount2", default=0): vol.Coerce(int),
+    }
+)
+
+FEED_DAY_SCHEMA = vol.Schema(
+    {
+        vol.Required("repeats"): vol.Any(cv.positive_int, cv.string),
+        vol.Required("items"): vol.All(cv.ensure_list, [FEED_ITEM_SCHEMA]),
+        vol.Optional("suspended", default=0): vol.Coerce(int),
+    }
+)
+
+SERVICE_SET_FEEDING_SCHEDULE_SCHEMA = vol.Schema(
+    {
+        vol.Required("device_id"): vol.Coerce(int),
+        vol.Required("feed_daily_list"): vol.All(
+            cv.ensure_list, [FEED_DAY_SCHEMA]
+        ),
+    }
+)
+
+
+def _build_feed_daily_list(feed_daily_list: list[dict]) -> list[dict]:
+    """Transform the user-friendly service call data into the Petkit API format.
+
+    Adds computed fields (count, totalAmount, totalAmount1, totalAmount2) and
+    normalizes each feed item to include all required API fields with defaults.
+    """
+    result = []
+    for day in feed_daily_list:
+        items = []
+        total_amount = 0
+        total_amount1 = 0
+        total_amount2 = 0
+        for item in day["items"]:
+            amount = item.get("amount", 0)
+            amount1 = item.get("amount1", 0)
+            amount2 = item.get("amount2", 0)
+            total_amount += amount
+            total_amount1 += amount1
+            total_amount2 += amount2
+            items.append(
+                {
+                    "amount": amount,
+                    "amount1": amount1,
+                    "amount2": amount2,
+                    "deviceId": 0,
+                    "deviceType": 0,
+                    "id": item["time"],
+                    "name": item["name"],
+                    "petAmount": [],
+                    "time": item["time"],
+                }
+            )
+        result.append(
+            {
+                "count": len(items),
+                "items": items,
+                "repeats": str(day["repeats"]),
+                "suspended": day.get("suspended", 0),
+                "totalAmount": total_amount,
+                "totalAmount1": total_amount1,
+                "totalAmount2": total_amount2,
+            }
+        )
+    return result
+
+
+async def _async_handle_set_feeding_schedule(
+    hass: HomeAssistant, call: ServiceCall
+) -> None:
+    """Handle the set_feeding_schedule service call."""
+    device_id = call.data["device_id"]
+    feed_daily_list = call.data["feed_daily_list"]
+
+    # Find the client that owns this device
+    client: PetKitClient | None = None
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        if hasattr(entry, "runtime_data") and entry.runtime_data:
+            candidate = entry.runtime_data.client
+            if device_id in candidate.petkit_entities:
+                device = candidate.petkit_entities[device_id]
+                if isinstance(device, Feeder):
+                    client = candidate
+                    break
+
+    if client is None:
+        raise ValueError(
+            f"Feeder with device_id {device_id} not found. "
+            "Ensure the device_id matches a registered Petkit feeder."
+        )
+
+    api_payload = _build_feed_daily_list(feed_daily_list)
+
+    LOGGER.debug(
+        "Setting feeding schedule for device %s with %d day(s)",
+        device_id,
+        len(api_payload),
+    )
+
+    await client.send_api_request(
+        device_id, FeederCommand.SAVE_FEED, api_payload
+    )
 
 
 async def async_setup_entry(
@@ -141,6 +257,20 @@ async def async_setup_entry(
     hass.data[DOMAIN][COORDINATOR] = coordinator
     hass.data[DOMAIN][COORDINATOR_MEDIA] = coordinator
     hass.data[DOMAIN][COORDINATOR_BLUETOOTH] = coordinator
+
+    # Register services (idempotent — only registers once per domain)
+    if not hass.services.has_service(DOMAIN, SERVICE_SET_FEEDING_SCHEDULE):
+
+        async def handle_set_feeding_schedule(call: ServiceCall) -> None:
+            """Wrapper so HA detects this as a coroutine function."""
+            await _async_handle_set_feeding_schedule(hass, call)
+
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_SET_FEEDING_SCHEDULE,
+            handle_set_feeding_schedule,
+            schema=SERVICE_SET_FEEDING_SCHEDULE_SCHEMA,
+        )
 
     return True
 

--- a/custom_components/petkit/entity.py
+++ b/custom_components/petkit/entity.py
@@ -30,6 +30,7 @@ class PetKitDescSensorBase(EntityDescription):
     """A class that describes sensor entities."""
 
     value: Callable[[_DevicesT], Any] | None = None
+    attributes: Callable[[_DevicesT], dict[str, Any] | None] | None = None
     ignore_types: list[str] | None = None  # List of device types to ignore
     only_for_types: list[str] | None = None  # List of device types to support
     force_add: list[str] | None = None

--- a/custom_components/petkit/sensor.py
+++ b/custom_components/petkit/sensor.py
@@ -51,7 +51,12 @@ from homeassistant.const import (
 
 from .const import BATTERY_LEVEL_MAP, DEVICE_STATUS_MAP, DOMAIN, LOGGER, NO_ERROR
 from .entity import PetKitDescSensorBase, PetkitEntity
-from .utils import get_raw_feed_plan, get_raw_feed_plan_from_schedule, get_raw_schedule, map_litter_event, map_work_state
+from .utils import (
+    get_raw_feed_plan_from_schedule,
+    get_raw_schedule,
+    map_litter_event,
+    map_work_state,
+)
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant

--- a/custom_components/petkit/sensor.py
+++ b/custom_components/petkit/sensor.py
@@ -51,7 +51,7 @@ from homeassistant.const import (
 
 from .const import BATTERY_LEVEL_MAP, DEVICE_STATUS_MAP, DOMAIN, LOGGER, NO_ERROR
 from .entity import PetKitDescSensorBase, PetkitEntity
-from .utils import get_raw_feed_plan, map_litter_event, map_work_state
+from .utils import get_raw_feed_plan, get_raw_feed_plan_from_schedule, get_raw_schedule, map_litter_event, map_work_state
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -334,7 +334,8 @@ SENSOR_MAPPING: dict[type[PetkitDevices], list[PetKitSensorDesc]] = {
             key="RAW distribution data",
             translation_key="raw_distribution_data",
             entity_category=EntityCategory.DIAGNOSTIC,
-            value=lambda device: get_raw_feed_plan(device.device_records),
+            value=lambda device: get_raw_feed_plan_from_schedule(device),
+            attributes=lambda device: get_raw_schedule(device),
             force_add=[D4H, D4SH],
         ),
     ],
@@ -884,6 +885,15 @@ class PetkitSensor(PetkitEntity, SensorEntity):
         device_data = self.coordinator.data.get(self.device.id)
         if device_data:
             return self.entity_description.value(device_data)
+        return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return extra state attributes."""
+        if self.entity_description.attributes:
+            device_data = self.coordinator.data.get(self.device.id)
+            if device_data:
+                return self.entity_description.attributes(device_data)
         return None
 
     @property

--- a/custom_components/petkit/services.yaml
+++ b/custom_components/petkit/services.yaml
@@ -1,0 +1,44 @@
+set_feeding_schedule:
+  name: Set feeding schedule
+  description: >
+    Replace the full feeding schedule on a Petkit feeder.
+    Each entry in feed_daily_list represents one day of the week (repeats 1-7 = Mon-Sun).
+    For dual-hopper feeders (D4S / D4SH), use amount1 and amount2.
+    For single-hopper feeders, use amount.
+    Time is in seconds since midnight (e.g. 21600 = 06:00, 43200 = 12:00).
+  fields:
+    device_id:
+      name: Device ID
+      description: The numeric Petkit device ID of the feeder.
+      required: true
+      example: 10014481
+      selector:
+        number:
+          min: 1
+          mode: box
+    feed_daily_list:
+      name: Feed daily list
+      description: >
+        A list of day schedules. Each day has a repeats value (1-7 for Mon-Sun),
+        a suspended flag (0=active, 1=suspended), and an items list.
+        Each item has: time (seconds since midnight), name (string),
+        amount (single hopper), amount1 (hopper 1), amount2 (hopper 2).
+      required: true
+      example:
+        - repeats: 1
+          suspended: 0
+          items:
+            - time: 21600
+              name: Breakfast
+              amount1: 3
+              amount2: 3
+            - time: 43200
+              name: Lunch
+              amount1: 2
+              amount2: 2
+            - time: 75600
+              name: Dinner
+              amount1: 5
+              amount2: 5
+      selector:
+        object:

--- a/custom_components/petkit/utils.py
+++ b/custom_components/petkit/utils.py
@@ -131,14 +131,14 @@ def get_raw_feed_plan_from_schedule(feeder) -> str | None:
         current_seconds = now.hour * 3600 + now.minute * 60 + now.second
 
         for feed in records.feed:
-            for item in (feed.items or []):
+            for item in feed.items or []:
                 t = getattr(item, "time", 0) or 0
                 src = getattr(item, "src", 0) or 0
                 status_val = getattr(item, "status", 0) or 0
                 item_state = getattr(item, "state", None)
 
                 state = 0  # pending
-                if (item_state is None and status_val == 0 and t < current_seconds):
+                if item_state is None and status_val == 0 and t < current_seconds:
                     state = 6  # unknown / past due
                 elif status_val == 1:
                     state = 7  # cancelled

--- a/custom_components/petkit/utils.py
+++ b/custom_components/petkit/utils.py
@@ -62,6 +62,116 @@ def map_work_state(work_state: WorkState | None) -> str:
     return _WORK_MODE_MAPPING.get(work_state.work_mode, lambda: "idle")()
 
 
+def get_raw_schedule(feeder) -> dict[str, any] | None:
+    """Get the full 7-day feeding schedule with per-hopper amounts.
+
+    Returns a dict suitable for extra_state_attributes containing:
+      - device_id: int
+      - feed_daily_list: list of day objects, each with items preserving
+        amount1/amount2 for dual-hopper round-trip editing.
+    """
+    multi = getattr(feeder, "multi_feed_item", None)
+    if multi is None or multi.feed_daily_list is None:
+        return None
+
+    days = []
+    for day in multi.feed_daily_list:
+        items = []
+        for item in day.items or []:
+            items.append(
+                {
+                    "time": getattr(item, "time", None),
+                    "name": getattr(item, "name", None),
+                    "amount": getattr(item, "amount", None),
+                    "amount1": getattr(item, "amount1", None),
+                    "amount2": getattr(item, "amount2", None),
+                    "id": getattr(item, "id", None),
+                }
+            )
+        days.append(
+            {
+                "repeats": getattr(day, "repeats", None),
+                "suspended": getattr(day, "suspended", None),
+                "count": len(items),
+                "items": items,
+            }
+        )
+
+    return {
+        "device_id": feeder.id,
+        "feed_daily_list": days,
+    }
+
+
+def get_raw_feed_plan_from_schedule(feeder) -> str | None:
+    """Get the feed plan from the schedule definition (multi_feed_item).
+
+    Unlike get_raw_feed_plan() which uses the execution log (growing unbounded),
+    this reads the fixed-size schedule definition and cross-references with
+    execution records for live status. Always under 255 chars for HA state limit.
+
+    :param feeder: Feeder device object
+    :return: A string with the feed plan in the format "id,hours,minutes,amount,state"
+    """
+    multi = getattr(feeder, "multi_feed_item", None)
+    if multi is None or multi.feed_daily_list is None:
+        return None
+
+    # Use first day's schedule definition (all days share the same items)
+    day = multi.feed_daily_list[0] if multi.feed_daily_list else None
+    if day is None or not day.items:
+        return None
+
+    # Build execution status lookup from device_records.feed
+    # Key: time_in_seconds → status code
+    status_lookup = {}
+    records = getattr(feeder, "device_records", None)
+    if records and getattr(records, "feed", None):
+        now = datetime.now()
+        current_seconds = now.hour * 3600 + now.minute * 60 + now.second
+
+        for feed in records.feed:
+            for item in (feed.items or []):
+                t = getattr(item, "time", 0) or 0
+                src = getattr(item, "src", 0) or 0
+                status_val = getattr(item, "status", 0) or 0
+                item_state = getattr(item, "state", None)
+
+                state = 0  # pending
+                if (item_state is None and status_val == 0 and t < current_seconds):
+                    state = 6  # unknown / past due
+                elif status_val == 1:
+                    state = 7  # cancelled
+                elif item_state is not None:
+                    err_code = getattr(item_state, "err_code", -1)
+                    result_code = getattr(item_state, "result", -1)
+                    if err_code == 0 and result_code == 0:
+                        state = {1: 1, 3: 2, 4: 3}.get(src, 1)
+                    elif err_code == 10 and result_code == 8:
+                        state = 8  # skipped
+                    else:
+                        state = 9  # error
+                # Only store if we have a definitive status (not just pending)
+                if state != 0 or t not in status_lookup:
+                    status_lookup[t] = state
+
+    # Generate state string from schedule definition
+    result = []
+    for idx, item in enumerate(day.items):
+        t = getattr(item, "time", 0) or 0
+        hours = t // 3600
+        minutes = (t % 3600) // 60
+        a1 = getattr(item, "amount1", 0) or 0
+        a2 = getattr(item, "amount2", 0) or 0
+        amount = getattr(item, "amount", None)
+        if amount is None or amount == 0:
+            amount = a1 + a2
+        state = status_lookup.get(t, 0)
+        result.append(f"{idx},{hours},{minutes},{amount},{state}")
+
+    return ",".join(result) if result else None
+
+
 def get_raw_feed_plan(feeder_records_data) -> str | None:
     """Get the raw feed plan from feeder data.
 

--- a/custom_components/petkit/utils.py
+++ b/custom_components/petkit/utils.py
@@ -76,18 +76,17 @@ def get_raw_schedule(feeder) -> dict[str, any] | None:
 
     days = []
     for day in multi.feed_daily_list:
-        items = []
-        for item in day.items or []:
-            items.append(
-                {
-                    "time": getattr(item, "time", None),
-                    "name": getattr(item, "name", None),
-                    "amount": getattr(item, "amount", None),
-                    "amount1": getattr(item, "amount1", None),
-                    "amount2": getattr(item, "amount2", None),
-                    "id": getattr(item, "id", None),
-                }
-            )
+        items = [
+            {
+                "time": getattr(item, "time", None),
+                "name": getattr(item, "name", None),
+                "amount": getattr(item, "amount", None),
+                "amount1": getattr(item, "amount1", None),
+                "amount2": getattr(item, "amount2", None),
+                "id": getattr(item, "id", None),
+            }
+            for item in day.items or []
+        ]
         days.append(
             {
                 "repeats": getattr(day, "repeats", None),


### PR DESCRIPTION
## Summary
Adds native feeding schedule management to the PetKit HA integration with dual-hopper (D4H/D4SH) support.

### Changes
- **__init__.py**: Register petkit.set_feeding_schedule HA service with voluptuous schema
- **utils.py**: Add get_raw_feed_plan_from_schedule() (fixed-size state, avoids HA 255-char limit) and get_raw_schedule() (per-hopper entity attributes with amount1/amount2)
- **entity.py**: Add xtra_state_attributes callback on PetKitDescSensorBase
- **sensor.py**: Wire attributes to RAW distribution data sensor for D4H/D4SH

### Dependencies
- **Depends on**: [py-petkit-api#53](https://github.com/Jezza34000/py-petkit-api/pull/53) — SAVE_FEED command
- **Depended by**: [dispenser-schedule-card#10](https://github.com/cristianchelu/dispenser-schedule-card/pull/10) — Matrix card