### PR TITLE
feat: add native HA persistent notifications for device events (closes #143)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -87,7 +87,7 @@ Camera entities use WebRTC via Agora SDK or go2rtc. Supporting files: `agora_api
 ### Notifications & MQTT
 
 - `PetkitIotMqttListener` (`iot_mqtt.py`) subscribes to Petkit's IoT MQTT broker and triggers smart polling on events.
-- `PetkitNotificationManager` (`notifications.py`) handles push notifications from the API.
+- `PetkitNotificationManager` (`notifications.py`) manages Home Assistant persistent notifications based on coordinator refreshes.
 
 ## Key Conventions
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,96 @@
+# Copilot Instructions
+
+## Project Overview
+
+This is a [HACS](https://hacs.xyz/) custom integration for Home Assistant that connects Petkit smart pet devices (feeders, litter boxes, water fountains, purifiers) via the `pypetkitapi` library. It lives entirely under `custom_components/petkit/`.
+
+## Linting
+
+Pre-commit hooks run **black**, **ruff**, and **codespell**:
+
+```bash
+pre-commit run --all-files          # run all hooks
+pre-commit run black --all-files    # run a single hook
+```
+
+CI runs hooks via tox:
+
+```bash
+python -m tox -e precommit
+```
+
+Validation against Home Assistant standards uses:
+- `hassfest` (HA's own validation tool)
+- HACS validation action
+
+There are no automated tests in this repo beyond pre-commit lint checks.
+
+## Architecture
+
+### Three Coordinators
+
+All data flows through three `DataUpdateCoordinator` subclasses defined in `coordinator.py`:
+
+| Coordinator | Purpose | Polling |
+|---|---|---|
+| `PetkitDataUpdateCoordinator` | Fetches all device state via `pypetkitapi` | 60 s default; 5 s "fast" after MQTT event; 190 s when MQTT connected |
+| `PetkitMediaUpdateCoordinator` | Downloads/manages camera media files to `/media` | Configurable (default 15 min) |
+| `PetkitBluetoothUpdateCoordinator` | Opens/closes BLE relay connections for water fountains | Configurable (default 30 min) |
+
+All three are stored in `entry.runtime_data` (a `PetkitData` dataclass defined in `data.py`).
+
+### Smart Polling
+
+`PetkitDataUpdateCoordinator` supports "smart polling": when an MQTT event arrives (via `PetkitIotMqttListener` in `iot_mqtt.py`), it calls `enable_smart_polling(nb_tic)` to temporarily switch to 5-second intervals for a fixed number of ticks, then reverts to 190 s (MQTT connected) or 60 s (no MQTT).
+
+### Entity Pattern
+
+Every HA platform (sensor, switch, button, etc.) follows the same structure:
+
+1. **Descriptor dataclass** — extends `PetKitDescSensorBase` (from `entity.py`) and the matching HA `*EntityDescription`. Key fields:
+   - `value: Callable[[device], Any]` — extracts the state; returning `None` signals the entity is unsupported on that device
+   - `ignore_types` / `only_for_types` — per-device-model filtering
+   - `force_add` — bypasses value-lambda check for specific device types
+2. **`COMMON_ENTITIES`** list + **`{PLATFORM}_MAPPING`** dict — maps device types (`Feeder`, `Litter`, etc.) to their descriptor lists
+3. **Entity class** — extends `PetkitEntity` (which extends `CoordinatorEntity`) and the HA platform entity
+
+`PetKitDescSensorBase.is_supported(device)` runs at setup time to filter which entities are registered for each physical device.
+
+### Device Filtering in Descriptors
+
+When writing a new entity descriptor, control device compatibility using:
+- `only_for_types=["t6", "t7"]` — allowlist by device type string (lowercase)
+- `ignore_types=["feeder_mini"]` — denylist
+- `force_add=["d4h"]` — skip value-lambda check and always add
+- `value` returning `None` or raising `AttributeError` — entity silently excluded
+
+Device type strings come from `pypetkitapi` constants (e.g., `T6`, `T7`, `D4H`, `DEVICES_LITTER_BOX`).
+
+### Unique IDs
+
+Entity unique IDs follow the pattern:
+```
+{device_type}_{device_sn}_{entity_key}
+```
+
+### Translations
+
+All entity `translation_key` values must have a matching entry in `translations/en.json` (and ideally all other locale files). The key structure mirrors Home Assistant's entity translation schema.
+
+### Camera / Streaming
+
+Camera entities use WebRTC via Agora SDK or go2rtc. Supporting files: `agora_api.py`, `agora_rtm.py`, `agora_sdp.py`, `agora_websocket.py`, `go2rtc_stream.py`, `webrtc_common.py`, `whep_mirror.py`. The WHEP mirror HTTP views are registered once at `async_setup_entry` time.
+
+### Notifications & MQTT
+
+- `PetkitIotMqttListener` (`iot_mqtt.py`) subscribes to Petkit's IoT MQTT broker and triggers smart polling on events.
+- `PetkitNotificationManager` (`notifications.py`) handles push notifications from the API.
+
+## Key Conventions
+
+- All files start with `from __future__ import annotations`.
+- `TYPE_CHECKING` blocks are used for all coordinator/config-entry type imports to avoid circular imports.
+- `LOGGER` is always imported from `.const` — never create a new logger directly.
+- Use `pypetkitapi` device type constants (`T6`, `DEVICES_LITTER_BOX`, etc.) rather than raw strings when possible.
+- Options config is split into named sections: `BT_SECTION` (`"bluetooth_options"`) and `MEDIA_SECTION` (`"medias_options"`).
+- Python 3.14 is targeted (see `pyproject.toml` and CI matrix).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -93,7 +93,7 @@ Camera entities use WebRTC via Agora SDK or go2rtc. Supporting files: `agora_api
 
 - All files start with `from __future__ import annotations`.
 - `TYPE_CHECKING` blocks are used for all coordinator/config-entry type imports to avoid circular imports.
-- `LOGGER` is always imported from `.const` — never create a new logger directly.
+- Logging currently uses a mixed pattern: some modules import `LOGGER` from `.const`, while others define a module-local logger with `logging.getLogger(__name__)`. Follow the existing pattern in the file you are editing, and avoid introducing a second logger style within the same module unless the file is being intentionally refactored.
 - Use `pypetkitapi` device type constants (`T6`, `DEVICES_LITTER_BOX`, etc.) rather than raw strings when possible.
 - Options config is split into named sections: `BT_SECTION` (`"bluetooth_options"`) and `MEDIA_SECTION` (`"medias_options"`).
 - Python 3.14 is targeted (see `pyproject.toml` and CI matrix).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,6 +20,7 @@ python -m tox -e precommit
 ```
 
 Validation against Home Assistant standards uses:
+
 - `hassfest` (HA's own validation tool)
 - HACS validation action
 
@@ -31,11 +32,11 @@ There are no automated tests in this repo beyond pre-commit lint checks.
 
 All data flows through three `DataUpdateCoordinator` subclasses defined in `coordinator.py`:
 
-| Coordinator | Purpose | Polling |
-|---|---|---|
-| `PetkitDataUpdateCoordinator` | Fetches all device state via `pypetkitapi` | 60 s default; 5 s "fast" after MQTT event; 190 s when MQTT connected |
-| `PetkitMediaUpdateCoordinator` | Downloads/manages camera media files to `/media` | Configurable (default 15 min) |
-| `PetkitBluetoothUpdateCoordinator` | Opens/closes BLE relay connections for water fountains | Configurable (default 30 min) |
+| Coordinator                        | Purpose                                                | Polling                                                              |
+| ---------------------------------- | ------------------------------------------------------ | -------------------------------------------------------------------- |
+| `PetkitDataUpdateCoordinator`      | Fetches all device state via `pypetkitapi`             | 60 s default; 5 s "fast" after MQTT event; 190 s when MQTT connected |
+| `PetkitMediaUpdateCoordinator`     | Downloads/manages camera media files to `/media`       | Configurable (default 15 min)                                        |
+| `PetkitBluetoothUpdateCoordinator` | Opens/closes BLE relay connections for water fountains | Configurable (default 30 min)                                        |
 
 All three are stored in `entry.runtime_data` (a `PetkitData` dataclass defined in `data.py`).
 
@@ -59,6 +60,7 @@ Every HA platform (sensor, switch, button, etc.) follows the same structure:
 ### Device Filtering in Descriptors
 
 When writing a new entity descriptor, control device compatibility using:
+
 - `only_for_types=["t6", "t7"]` — allowlist by device type string (lowercase)
 - `ignore_types=["feeder_mini"]` — denylist
 - `force_add=["d4h"]` — skip value-lambda check and always add
@@ -69,6 +71,7 @@ Device type strings come from `pypetkitapi` constants (e.g., `T6`, `T7`, `D4H`, 
 ### Unique IDs
 
 Entity unique IDs follow the pattern:
+
 ```
 {device_type}_{device_sn}_{entity_key}
 ```

--- a/custom_components/petkit/__init__.py
+++ b/custom_components/petkit/__init__.py
@@ -138,6 +138,7 @@ async def async_setup_entry(
         hass=hass,
         coordinator=coordinator,
     )
+    await notification_manager.async_start()
     entry.runtime_data.notification_manager = notification_manager
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/petkit/__init__.py
+++ b/custom_components/petkit/__init__.py
@@ -37,6 +37,7 @@ from .coordinator import (
 )
 from .data import PetkitData
 from .iot_mqtt import PetkitIotMqttListener
+from .notifications import PetkitNotificationManager
 from .whep_mirror import (
     PetkitInternalWhepMirrorView,
     PetkitWhepMirrorView,
@@ -132,6 +133,13 @@ async def async_setup_entry(
     entry.runtime_data.mqtt_listener = mqtt_listener
     await mqtt_listener.async_start()
 
+    # Notifications
+    notification_manager = PetkitNotificationManager(
+        hass=hass,
+        coordinator=coordinator,
+    )
+    entry.runtime_data.notification_manager = notification_manager
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
@@ -153,6 +161,10 @@ async def async_unload_entry(
     mqtt_listener = getattr(entry.runtime_data, "mqtt_listener", None)
     if mqtt_listener is not None:
         await mqtt_listener.async_stop()
+
+    notification_manager = getattr(entry.runtime_data, "notification_manager", None)
+    if notification_manager is not None:
+        notification_manager.stop()
 
     await async_cleanup_whep_mirror_sessions(hass)
 

--- a/custom_components/petkit/data.py
+++ b/custom_components/petkit/data.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
         PetkitMediaUpdateCoordinator,
     )
     from .iot_mqtt import PetkitIotMqttListener
+    from .notifications import PetkitNotificationManager
 
 type PetkitConfigEntry = ConfigEntry[PetkitData]
 
@@ -36,3 +37,4 @@ class PetkitData:
     coordinator_bluetooth: PetkitBluetoothUpdateCoordinator
     integration: Integration
     mqtt_listener: PetkitIotMqttListener | None = None
+    notification_manager: PetkitNotificationManager | None = None

--- a/custom_components/petkit/notifications.py
+++ b/custom_components/petkit/notifications.py
@@ -84,9 +84,10 @@ def _safe_get(obj: Any, *attrs: str, default: Any = None) -> Any:
     try:
         for attr in attrs:
             obj = getattr(obj, attr)
-        return obj
     except AttributeError:
         return default
+    else:
+        return obj
 
 
 def _device_name(device: Any) -> str:

--- a/custom_components/petkit/notifications.py
+++ b/custom_components/petkit/notifications.py
@@ -2,10 +2,10 @@
 
 Fires a native Home Assistant persistent notification whenever a relevant
 device event occurs (litter-box cleaning result, waste bin full, low food,
-low water, etc.).  Each notification type is gated by the corresponding
-notification switch already present on the device
-(e.g. ``work_notify``, ``litter_full_notify``) so users can opt-out of
-individual alerts directly from the integration's switch entities.
+low water, etc.). Some notification types may be controlled by the
+corresponding device notification switches when those switches are available
+(for example, ``work_notify`` or ``litter_full_notify``), allowing users to
+opt out of those specific alerts from the integration's switch entities.
 
 When a binary alert clears (e.g. the waste bin has been emptied) the
 matching persistent notification is automatically dismissed.

--- a/custom_components/petkit/notifications.py
+++ b/custom_components/petkit/notifications.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from pypetkitapi import Feeder, Litter, WaterFountain
+from pypetkitapi import D3, D4S, D4SH, Feeder, Litter, WaterFountain
 
 from homeassistant.components.persistent_notification import async_create, async_dismiss
 
@@ -26,6 +26,57 @@ if TYPE_CHECKING:
     from .coordinator import PetkitDataUpdateCoordinator
 
 LOGGER = logging.getLogger(__name__)
+
+# Human-readable translations for litter event keys returned by map_litter_event().
+# Mirrors the state translations in translations/en.json so notifications
+# show friendly text instead of raw translation keys.
+_LITTER_EVENT_LABELS: dict[str, str] = {
+    "auto_cleaning_canceled": "Auto cleaning canceled",
+    "auto_cleaning_canceled_kitten": "Auto cleaning canceled: kitten mode",
+    "auto_cleaning_completed": "Auto cleaning completed",
+    "auto_cleaning_failed_full": "Auto cleaning failed: waste bin full",
+    "auto_cleaning_failed_hall_l": "Auto cleaning failed: hall sensor L",
+    "auto_cleaning_failed_hall_t": "Auto cleaning failed: hall sensor T",
+    "auto_cleaning_terminated": "Auto cleaning terminated",
+    "auto_odor_failed": "Auto deodorization failed",
+    "clean_over": "Clean",
+    "deodorant_finished": "Deodorization finished",
+    "deodorant_finished_liquid_lack": "Deodorization finished: liquid low",
+    "light_over": "Light",
+    "litter_empty_completed": "Litter empty completed",
+    "litter_empty_failed_full": "Litter empty failed: waste bin full",
+    "litter_empty_failed_hall_l": "Litter empty failed: hall sensor L",
+    "litter_empty_failed_hall_t": "Litter empty failed: hall sensor T",
+    "litter_empty_terminated": "Litter empty terminated",
+    "manual_cleaning_canceled": "Manual cleaning canceled",
+    "manual_cleaning_completed": "Manual cleaning completed",
+    "manual_cleaning_failed_full": "Manual cleaning failed: waste bin full",
+    "manual_cleaning_failed_hall_l": "Manual cleaning failed: hall sensor L",
+    "manual_cleaning_failed_hall_t": "Manual cleaning failed: hall sensor T",
+    "manual_cleaning_terminated": "Manual cleaning terminated",
+    "manual_odor_completed": "Manual deodorization completed",
+    "manual_odor_completed_liquid_lack": "Manual deodorization completed: liquid low",
+    "manual_odor_failed": "Manual deodorization failed",
+    "periodic_cleaning_canceled": "Periodic cleaning canceled",
+    "periodic_cleaning_canceled_kitten": "Periodic cleaning canceled: kitten mode",
+    "periodic_cleaning_completed": "Periodic cleaning completed",
+    "periodic_cleaning_terminated": "Periodic cleaning terminated",
+    "periodic_odor_completed": "Periodic deodorization completed",
+    "periodic_odor_completed_liquid_lack": "Periodic deodorization completed: liquid low",
+    "periodic_odor_failed": "Periodic deodorization failed",
+    "pet_detect": "Pet detected",
+    "pet_out": "Pet out",
+    "reset_completed": "Reset completed",
+    "reset_failed_full": "Reset failed: waste bin full",
+    "reset_failed_hall_l": "Reset failed: hall sensor L",
+    "reset_failed_hall_t": "Reset failed: hall sensor T",
+    "reset_over": "Reset",
+    "reset_terminated": "Reset terminated",
+    "scheduled_cleaning_failed_full": "Scheduled cleaning failed: waste bin full",
+    "scheduled_cleaning_failed_hall_l": "Scheduled cleaning failed: hall sensor L",
+    "scheduled_cleaning_failed_hall_t": "Scheduled cleaning failed: hall sensor T",
+    "spray_over": "Deodorize",
+}
 
 
 def _safe_get(obj: Any, *attrs: str, default: Any = None) -> Any:
@@ -65,7 +116,9 @@ class PetkitNotificationManager:
         self.hass = hass
         self._coordinator = coordinator
         self._prev_litter_events: dict[int, str | None] = {}
-        self._prev_binary: dict[str, bool] = {}
+        # Uses Optional[bool] as sentinel: None = not yet seen (first pass seeds
+        # state without firing), True/False = known previous state.
+        self._prev_binary: dict[str, bool | None] = {}
         self._remove_listener = coordinator.async_add_listener(
             self._handle_coordinator_update
         )
@@ -102,11 +155,18 @@ class PetkitNotificationManager:
 
         Returns ``(rose, fell)`` where *rose* means a False→True transition
         occurred and *fell* means a True→False transition occurred.
+
+        On the first call for a given key the state is seeded without
+        reporting any transition, preventing spurious notifications on
+        HA start or integration reload.
         """
         state_key = f"{device_id}_{key}"
-        prev = self._prev_binary.get(state_key, False)
+        prev = self._prev_binary.get(state_key)
         current_bool = bool(current)
         self._prev_binary[state_key] = current_bool
+        # First observation — seed without transition
+        if prev is None:
+            return False, False
         return current_bool and not prev, not current_bool and prev
 
     # ------------------------------------------------------------------
@@ -123,10 +183,14 @@ class PetkitNotificationManager:
         if current_event and current_event != prev_event:
             self._prev_litter_events[device.id] = current_event
             if self._notif_enabled(device, "work_notify"):
+                # map_litter_event returns translation keys for most events.
+                # Look up the human-readable label; fall back to the raw key
+                # for pet-visit strings (which are already human-readable).
+                label = _LITTER_EVENT_LABELS.get(current_event, current_event)
                 self._notify(
                     f"petkit_{device.id}_litter_event",
                     f"PetKit — {_device_name(device)}",
-                    current_event,
+                    label,
                 )
 
         # --- Waste bin full ---
@@ -156,9 +220,25 @@ class PetkitNotificationManager:
             self._dismiss(f"petkit_{device.id}_sand_lack")
 
     def _check_feeder(self, device: Feeder) -> None:
-        """Check feeder food-level alerts."""
-        food_state = _safe_get(device, "state", "food")
-        food_low = food_state is not None and food_state < 2
+        """Check feeder food-level alerts.
+
+        Uses the same per-model thresholds as the food_level binary sensors:
+        - D4S / D4SH (dual hopper): alert when hopper 1 *or* hopper 2 is empty
+        - D3: alert when food level < 2 (levels 0 or 1)
+        - All other feeders: alert when food level == 0
+        """
+        if isinstance(device, (D4S, D4SH)):
+            food1 = _safe_get(device, "state", "food1")
+            food2 = _safe_get(device, "state", "food2")
+            food_low = (food1 is not None and food1 == 0) or (
+                food2 is not None and food2 == 0
+            )
+        elif isinstance(device, D3):
+            food_state = _safe_get(device, "state", "food")
+            food_low = food_state is not None and food_state < 2
+        else:
+            food_state = _safe_get(device, "state", "food")
+            food_low = food_state is not None and food_state == 0
         rose, fell = self._track_binary(device.id, "food_low", food_low)
         if rose and self._notif_enabled(device, "food_notify"):
             self._notify(
@@ -213,9 +293,8 @@ class PetkitNotificationManager:
                     self._check_feeder(device)
                 elif isinstance(device, WaterFountain):
                     self._check_fountain(device)
-            except Exception as exc:  # noqa: BLE001
-                LOGGER.warning(
-                    "PetKit: error while processing notification for device %s: %s",
+            except Exception:  # noqa: BLE001
+                LOGGER.exception(
+                    "PetKit: error while processing notification for device %s",
                     getattr(device, "id", "?"),
-                    exc,
                 )

--- a/custom_components/petkit/notifications.py
+++ b/custom_components/petkit/notifications.py
@@ -156,16 +156,21 @@ class PetkitNotificationManager:
 
         # --- Litter box event (cleaning completed / failed, pet visit, etc.) ---
         current_event = map_litter_event(device.device_records)
-        prev_event = self._prev_litter_events.get(device.id)
-        if current_event and current_event != prev_event:
+        if device.id not in self._prev_litter_events:
             self._prev_litter_events[device.id] = current_event
-            if self._notif_enabled(device, "work_notify"):
-                label = self._translate_litter_event(current_event)
-                self._notify(
-                    f"petkit_{device.id}_litter_event",
-                    f"PetKit — {_device_name(device)}",
-                    label,
-                )
+        else:
+            prev_event = self._prev_litter_events[device.id]
+            if current_event and current_event != prev_event:
+                self._prev_litter_events[device.id] = current_event
+                if self._notif_enabled(device, "work_notify"):
+                    label = self._translate_litter_event(current_event)
+                    self._notify(
+                        f"petkit_{device.id}_litter_event",
+                        f"PetKit — {_device_name(device)}",
+                        label,
+                    )
+            elif current_event != prev_event:
+                self._prev_litter_events[device.id] = current_event
 
         # --- Waste bin full ---
         rose, fell = self._track_binary(

--- a/custom_components/petkit/notifications.py
+++ b/custom_components/petkit/notifications.py
@@ -294,7 +294,7 @@ class PetkitNotificationManager:
                     self._check_feeder(device)
                 elif isinstance(device, WaterFountain):
                     self._check_fountain(device)
-            except Exception:  # noqa: BLE001
+            except Exception:
                 LOGGER.exception(
                     "PetKit: error while processing notification for device %s",
                     getattr(device, "id", "?"),

--- a/custom_components/petkit/notifications.py
+++ b/custom_components/petkit/notifications.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any
 from pypetkitapi import D3, D4S, D4SH, Feeder, Litter, WaterFountain
 
 from homeassistant.components.persistent_notification import async_create, async_dismiss
+from homeassistant.helpers import translation
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -27,56 +28,8 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 
-# Human-readable translations for litter event keys returned by map_litter_event().
-# Mirrors the state translations in translations/en.json so notifications
-# show friendly text instead of raw translation keys.
-_LITTER_EVENT_LABELS: dict[str, str] = {
-    "auto_cleaning_canceled": "Auto cleaning canceled",
-    "auto_cleaning_canceled_kitten": "Auto cleaning canceled: kitten mode",
-    "auto_cleaning_completed": "Auto cleaning completed",
-    "auto_cleaning_failed_full": "Auto cleaning failed: waste bin full",
-    "auto_cleaning_failed_hall_l": "Auto cleaning failed: hall sensor L",
-    "auto_cleaning_failed_hall_t": "Auto cleaning failed: hall sensor T",
-    "auto_cleaning_terminated": "Auto cleaning terminated",
-    "auto_odor_failed": "Auto deodorization failed",
-    "clean_over": "Clean",
-    "deodorant_finished": "Deodorization finished",
-    "deodorant_finished_liquid_lack": "Deodorization finished: liquid low",
-    "light_over": "Light",
-    "litter_empty_completed": "Litter empty completed",
-    "litter_empty_failed_full": "Litter empty failed: waste bin full",
-    "litter_empty_failed_hall_l": "Litter empty failed: hall sensor L",
-    "litter_empty_failed_hall_t": "Litter empty failed: hall sensor T",
-    "litter_empty_terminated": "Litter empty terminated",
-    "manual_cleaning_canceled": "Manual cleaning canceled",
-    "manual_cleaning_completed": "Manual cleaning completed",
-    "manual_cleaning_failed_full": "Manual cleaning failed: waste bin full",
-    "manual_cleaning_failed_hall_l": "Manual cleaning failed: hall sensor L",
-    "manual_cleaning_failed_hall_t": "Manual cleaning failed: hall sensor T",
-    "manual_cleaning_terminated": "Manual cleaning terminated",
-    "manual_odor_completed": "Manual deodorization completed",
-    "manual_odor_completed_liquid_lack": "Manual deodorization completed: liquid low",
-    "manual_odor_failed": "Manual deodorization failed",
-    "periodic_cleaning_canceled": "Periodic cleaning canceled",
-    "periodic_cleaning_canceled_kitten": "Periodic cleaning canceled: kitten mode",
-    "periodic_cleaning_completed": "Periodic cleaning completed",
-    "periodic_cleaning_terminated": "Periodic cleaning terminated",
-    "periodic_odor_completed": "Periodic deodorization completed",
-    "periodic_odor_completed_liquid_lack": "Periodic deodorization completed: liquid low",
-    "periodic_odor_failed": "Periodic deodorization failed",
-    "pet_detect": "Pet detected",
-    "pet_out": "Pet out",
-    "reset_completed": "Reset completed",
-    "reset_failed_full": "Reset failed: waste bin full",
-    "reset_failed_hall_l": "Reset failed: hall sensor L",
-    "reset_failed_hall_t": "Reset failed: hall sensor T",
-    "reset_over": "Reset",
-    "reset_terminated": "Reset terminated",
-    "scheduled_cleaning_failed_full": "Scheduled cleaning failed: waste bin full",
-    "scheduled_cleaning_failed_hall_l": "Scheduled cleaning failed: hall sensor L",
-    "scheduled_cleaning_failed_hall_t": "Scheduled cleaning failed: hall sensor T",
-    "spray_over": "Deodorize",
-}
+# Translation key prefix for litter last-event states (entity.sensor.litter_last_event.state.*)
+_LITTER_EVENT_TRANS_PREFIX = "component.petkit.entity.sensor.litter_last_event.state."
 
 
 def _safe_get(obj: Any, *attrs: str, default: Any = None) -> Any:
@@ -103,9 +56,10 @@ class PetkitNotificationManager:
     """Fires HA persistent notifications when PetKit device events occur.
 
     Instantiate once per config entry and pass in the main data coordinator.
-    The manager registers itself as a coordinator listener so it is called
-    automatically after every data refresh.  Call :meth:`stop` when the
-    config entry is unloaded to remove the listener.
+    Call :meth:`async_start` after instantiation (from an async context) to
+    load HA translations.  The manager then registers itself as a coordinator
+    listener so it is called automatically after every data refresh.  Call
+    :meth:`stop` when the config entry is unloaded to remove the listener.
     """
 
     def __init__(
@@ -113,16 +67,30 @@ class PetkitNotificationManager:
         hass: HomeAssistant,
         coordinator: PetkitDataUpdateCoordinator,
     ) -> None:
-        """Register as a coordinator listener."""
+        """Set up the notification manager (call async_start afterwards)."""
         self.hass = hass
         self._coordinator = coordinator
         self._prev_litter_events: dict[int, str | None] = {}
         # Uses Optional[bool] as sentinel: None = not yet seen (first pass seeds
         # state without firing), True/False = known previous state.
         self._prev_binary: dict[str, bool | None] = {}
+        # Loaded by async_start(); keys are full HA translation paths.
+        self._translations: dict[str, str] = {}
         self._remove_listener = coordinator.async_add_listener(
             self._handle_coordinator_update
         )
+
+    async def async_start(self) -> None:
+        """Load HA translations for notification messages."""
+        try:
+            self._translations = await translation.async_get_translations(
+                self.hass,
+                self.hass.config.language,
+                "entity",
+                integrations=["petkit"],
+            )
+        except Exception:  # noqa: BLE001
+            LOGGER.exception("PetKit: failed to load translations for notifications")
 
     def stop(self) -> None:
         """Unregister the coordinator listener (call on integration unload)."""
@@ -148,6 +116,14 @@ class PetkitNotificationManager:
         if setting_attr is None:
             return True
         return bool(_safe_get(device, "settings", setting_attr, default=False))
+
+    def _translate_litter_event(self, key: str) -> str:
+        """Return the translated label for a litter event key.
+
+        Uses HA's loaded translations (user language) and falls back to the
+        raw key when no translation is found.
+        """
+        return self._translations.get(f"{_LITTER_EVENT_TRANS_PREFIX}{key}", key)
 
     def _track_binary(
         self, device_id: int, key: str, current: Any
@@ -184,10 +160,7 @@ class PetkitNotificationManager:
         if current_event and current_event != prev_event:
             self._prev_litter_events[device.id] = current_event
             if self._notif_enabled(device, "work_notify"):
-                # map_litter_event returns translation keys for most events.
-                # Look up the human-readable label; fall back to the raw key
-                # for pet-visit strings (which are already human-readable).
-                label = _LITTER_EVENT_LABELS.get(current_event, current_event)
+                label = self._translate_litter_event(current_event)
                 self._notify(
                     f"petkit_{device.id}_litter_event",
                     f"PetKit — {_device_name(device)}",
@@ -220,6 +193,20 @@ class PetkitNotificationManager:
         elif fell:
             self._dismiss(f"petkit_{device.id}_sand_lack")
 
+        # --- Device error ---
+        error_msg = _safe_get(device, "state", "error_msg")
+        rose, fell = self._track_binary(
+            device.id, "error", error_msg is not None and bool(error_msg)
+        )
+        if rose:
+            self._notify(
+                f"petkit_{device.id}_error",
+                f"PetKit — {_device_name(device)}",
+                str(error_msg),
+            )
+        elif fell:
+            self._dismiss(f"petkit_{device.id}_error")
+
     def _check_feeder(self, device: Feeder) -> None:
         """Check feeder food-level alerts.
 
@@ -228,13 +215,14 @@ class PetkitNotificationManager:
         - D3: alert when food level < 2 (levels 0 or 1)
         - All other feeders: alert when food level == 0
         """
-        if isinstance(device, (D4S, D4SH)):
+        device_type = _safe_get(device, "device_nfo", "device_type", default="")
+        if device_type in (D4S, D4SH):
             food1 = _safe_get(device, "state", "food1")
             food2 = _safe_get(device, "state", "food2")
             food_low = (food1 is not None and food1 == 0) or (
                 food2 is not None and food2 == 0
             )
-        elif isinstance(device, D3):
+        elif device_type == D3:
             food_state = _safe_get(device, "state", "food")
             food_low = food_state is not None and food_state < 2
         else:
@@ -249,6 +237,20 @@ class PetkitNotificationManager:
             )
         elif fell:
             self._dismiss(f"petkit_{device.id}_food_low")
+
+        # --- Device error ---
+        error_msg = _safe_get(device, "state", "error_msg")
+        rose, fell = self._track_binary(
+            device.id, "error", error_msg is not None and bool(error_msg)
+        )
+        if rose:
+            self._notify(
+                f"petkit_{device.id}_error",
+                f"PetKit — {_device_name(device)}",
+                str(error_msg),
+            )
+        elif fell:
+            self._dismiss(f"petkit_{device.id}_error")
 
     def _check_fountain(self, device: WaterFountain) -> None:
         """Check water fountain alerts."""

--- a/custom_components/petkit/notifications.py
+++ b/custom_components/petkit/notifications.py
@@ -1,0 +1,221 @@
+"""HA persistent notification manager for Petkit Smart Devices integration.
+
+Fires a native Home Assistant persistent notification whenever a relevant
+device event occurs (litter-box cleaning result, waste bin full, low food,
+low water, etc.).  Each notification type is gated by the corresponding
+notification switch already present on the device
+(e.g. ``work_notify``, ``litter_full_notify``) so users can opt-out of
+individual alerts directly from the integration's switch entities.
+
+When a binary alert clears (e.g. the waste bin has been emptied) the
+matching persistent notification is automatically dismissed.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from pypetkitapi import Feeder, Litter, WaterFountain
+
+from homeassistant.components.persistent_notification import async_create, async_dismiss
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+    from .coordinator import PetkitDataUpdateCoordinator
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _safe_get(obj: Any, *attrs: str, default: Any = None) -> Any:
+    """Safely retrieve a chain of attributes without raising AttributeError."""
+    try:
+        for attr in attrs:
+            obj = getattr(obj, attr)
+        return obj
+    except AttributeError:
+        return default
+
+
+def _device_name(device: Any) -> str:
+    """Return a human-readable device name."""
+    return (
+        _safe_get(device, "device_nfo", "device_name")
+        or _safe_get(device, "name")
+        or f"PetKit device {device.id}"
+    )
+
+
+class PetkitNotificationManager:
+    """Fires HA persistent notifications when PetKit device events occur.
+
+    Instantiate once per config entry and pass in the main data coordinator.
+    The manager registers itself as a coordinator listener so it is called
+    automatically after every data refresh.  Call :meth:`stop` when the
+    config entry is unloaded to remove the listener.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        coordinator: PetkitDataUpdateCoordinator,
+    ) -> None:
+        """Register as a coordinator listener."""
+        self.hass = hass
+        self._coordinator = coordinator
+        self._prev_litter_events: dict[int, str | None] = {}
+        self._prev_binary: dict[str, bool] = {}
+        self._remove_listener = coordinator.async_add_listener(
+            self._handle_coordinator_update
+        )
+
+    def stop(self) -> None:
+        """Unregister the coordinator listener (call on integration unload)."""
+        self._remove_listener()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _notify(self, notification_id: str, title: str, message: str) -> None:
+        async_create(
+            self.hass,
+            message=message,
+            title=title,
+            notification_id=notification_id,
+        )
+
+    def _dismiss(self, notification_id: str) -> None:
+        async_dismiss(self.hass, notification_id)
+
+    def _notif_enabled(self, device: Any, setting_attr: str | None) -> bool:
+        """Return True when the device's notification switch is enabled (or always if None)."""
+        if setting_attr is None:
+            return True
+        return bool(_safe_get(device, "settings", setting_attr, default=False))
+
+    def _track_binary(
+        self, device_id: int, key: str, current: Any
+    ) -> tuple[bool, bool]:
+        """Track a boolean state across updates.
+
+        Returns ``(rose, fell)`` where *rose* means a False→True transition
+        occurred and *fell* means a True→False transition occurred.
+        """
+        state_key = f"{device_id}_{key}"
+        prev = self._prev_binary.get(state_key, False)
+        current_bool = bool(current)
+        self._prev_binary[state_key] = current_bool
+        return current_bool and not prev, not current_bool and prev
+
+    # ------------------------------------------------------------------
+    # Per-device-type checks
+    # ------------------------------------------------------------------
+
+    def _check_litter(self, device: Litter) -> None:
+        """Check litter box work events and binary alerts."""
+        from .utils import map_litter_event
+
+        # --- Litter box event (cleaning completed / failed, pet visit, etc.) ---
+        current_event = map_litter_event(device.device_records)
+        prev_event = self._prev_litter_events.get(device.id)
+        if current_event and current_event != prev_event:
+            self._prev_litter_events[device.id] = current_event
+            if self._notif_enabled(device, "work_notify"):
+                self._notify(
+                    f"petkit_{device.id}_litter_event",
+                    f"PetKit — {_device_name(device)}",
+                    current_event,
+                )
+
+        # --- Waste bin full ---
+        rose, fell = self._track_binary(
+            device.id, "box_full", _safe_get(device, "state", "box_full")
+        )
+        if rose and self._notif_enabled(device, "litter_full_notify"):
+            self._notify(
+                f"petkit_{device.id}_box_full",
+                f"PetKit — {_device_name(device)}",
+                "The waste bin is full and needs to be emptied.",
+            )
+        elif fell:
+            self._dismiss(f"petkit_{device.id}_box_full")
+
+        # --- Sand / litter level low ---
+        rose, fell = self._track_binary(
+            device.id, "sand_lack", _safe_get(device, "state", "sand_lack")
+        )
+        if rose and self._notif_enabled(device, "lack_sand_notify"):
+            self._notify(
+                f"petkit_{device.id}_sand_lack",
+                f"PetKit — {_device_name(device)}",
+                "Litter level is low. Please refill.",
+            )
+        elif fell:
+            self._dismiss(f"petkit_{device.id}_sand_lack")
+
+    def _check_feeder(self, device: Feeder) -> None:
+        """Check feeder food-level alerts."""
+        food_state = _safe_get(device, "state", "food")
+        food_low = food_state is not None and food_state < 2
+        rose, fell = self._track_binary(device.id, "food_low", food_low)
+        if rose and self._notif_enabled(device, "food_notify"):
+            self._notify(
+                f"petkit_{device.id}_food_low",
+                f"PetKit — {_device_name(device)}",
+                "Food level is low. Please refill.",
+            )
+        elif fell:
+            self._dismiss(f"petkit_{device.id}_food_low")
+
+    def _check_fountain(self, device: WaterFountain) -> None:
+        """Check water fountain alerts."""
+        # --- Water level low ---
+        rose, fell = self._track_binary(
+            device.id, "lack_warning", _safe_get(device, "lack_warning")
+        )
+        if rose and self._notif_enabled(device, "lack_liquid_notify"):
+            self._notify(
+                f"petkit_{device.id}_lack_warning",
+                f"PetKit — {_device_name(device)}",
+                "Water level is low. Please refill.",
+            )
+        elif fell:
+            self._dismiss(f"petkit_{device.id}_lack_warning")
+
+        # --- Filter needs replacement ---
+        rose, fell = self._track_binary(
+            device.id, "filter_warning", _safe_get(device, "filter_warning")
+        )
+        if rose:
+            self._notify(
+                f"petkit_{device.id}_filter_warning",
+                f"PetKit — {_device_name(device)}",
+                "The water filter needs to be replaced.",
+            )
+        elif fell:
+            self._dismiss(f"petkit_{device.id}_filter_warning")
+
+    # ------------------------------------------------------------------
+    # Coordinator update handler
+    # ------------------------------------------------------------------
+
+    def _handle_coordinator_update(self) -> None:
+        """Called by the coordinator after every successful data refresh."""
+        if not self._coordinator.data:
+            return
+        for device in self._coordinator.data.values():
+            try:
+                if isinstance(device, Litter):
+                    self._check_litter(device)
+                elif isinstance(device, Feeder):
+                    self._check_feeder(device)
+                elif isinstance(device, WaterFountain):
+                    self._check_fountain(device)
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.warning(
+                    "PetKit: error while processing notification for device %s: %s",
+                    getattr(device, "id", "?"),
+                    exc,
+                )

--- a/custom_components/petkit/notifications.py
+++ b/custom_components/petkit/notifications.py
@@ -89,7 +89,7 @@ class PetkitNotificationManager:
                 "entity",
                 integrations=["petkit"],
             )
-        except Exception:  # noqa: BLE001
+        except Exception:
             LOGGER.exception("PetKit: failed to load translations for notifications")
 
     def stop(self) -> None:


### PR DESCRIPTION
## Summary

Implements native Home Assistant persistent notifications for PetKit device events, as requested in #143.

## How it works

A new PetkitNotificationManager (notifications.py) registers as a coordinator listener and fires persistent_notification entries after every data refresh when a relevant condition is detected.

### Notification triggers

| Device | Condition | Gated by setting |
|---|---|---|
| Litter box | New work event (clean result, error, pet visit) | work_notify |
| Litter box | Waste bin full | litter_full_notify |
| Litter box | Sand / litter level low | lack_sand_notify |
| Feeder | Food level below threshold | ood_notify |
| Water fountain | Water level low | lack_liquid_notify |
| Water fountain | Filter needs replacement | always |

- Binary alerts (box full, sand low, food low, water low, filter) are **auto-dismissed** when the condition clears.
- Each notification type is gated by the corresponding switch already present on the device, so users can opt-out of individual alerts without touching HA automations.

## Files changed

- custom_components/petkit/notifications.py — new PetkitNotificationManager class
- custom_components/petkit/data.py — added 
otification_manager field to PetkitData
- custom_components/petkit/__init__.py — instantiate manager after first refresh; stop it on unload

## Follow-up fixes (addressing review feedback)

- **TypeError fixed** (_check_feeder): D4S, D4SH, D3 are string constants, not types. Replaced isinstance(device, (D4S, D4SH)) with device.device_nfo.device_type in (D4S, D4SH) string comparison.
- **HA translation service** (line 33): Removed the 70-line hardcoded _LITTER_EVENT_LABELS dict. Added sync_start() method that loads translations via homeassistant.helpers.translation.async_get_translations() in the user's configured language. Litter event labels now use the same translations already present in 	ranslations/*.json.
- **Litter error notification** (line 177): Added device.state.error_msg tracking in _check_litter(). Fires a notification (always, not gated) when an error message appears; auto-dismisses when it clears.
- **Feeder error notification** (line 223): Same pattern added to _check_feeder() for feeder error messages.