### PR TITLE
feat: add water fountain controls - working mode, LED brightness, DND (closes #94)

### DIFF
--- a/custom_components/petkit/__init__.py
+++ b/custom_components/petkit/__init__.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from pypetkitapi import PetKitClient
-from pypetkitapi.command import FOUNTAIN_COMMAND, FountainAction
 
 from homeassistant.const import (
     CONF_PASSWORD,
@@ -62,18 +61,6 @@ PLATFORMS: list[Platform] = [
     Platform.IMAGE,
     Platform.FAN,
 ]
-
-# Extend pypetkitapi's FOUNTAIN_COMMAND with working mode commands.
-# These byte sequences follow the same [cmd, type, length, start_data, state, mode, op_type]
-# format as the existing POWER_ON/OFF entries (cmd 220).
-FOUNTAIN_COMMAND.update(
-    {
-        FountainAction.MODE_NORMAL: [220, 1, 3, 0, 1, 1, 1],
-        FountainAction.MODE_SMART: [220, 1, 3, 0, 1, 2, 1],
-        FountainAction.MODE_STANDARD: [220, 1, 3, 0, 1, 1, 1],
-        FountainAction.MODE_INTERMITTENT: [220, 1, 3, 0, 1, 2, 1],
-    }
-)
 
 
 async def async_setup_entry(

--- a/custom_components/petkit/__init__.py
+++ b/custom_components/petkit/__init__.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from pypetkitapi import PetKitClient
+from pypetkitapi.command import FOUNTAIN_COMMAND, FountainAction
 
 from homeassistant.const import (
     CONF_PASSWORD,
@@ -61,6 +62,18 @@ PLATFORMS: list[Platform] = [
     Platform.IMAGE,
     Platform.FAN,
 ]
+
+# Extend pypetkitapi's FOUNTAIN_COMMAND with working mode commands.
+# These byte sequences follow the same [cmd, type, length, start_data, state, mode, op_type]
+# format as the existing POWER_ON/OFF entries (cmd 220).
+FOUNTAIN_COMMAND.update(
+    {
+        FountainAction.MODE_NORMAL: [220, 1, 3, 0, 1, 1, 1],
+        FountainAction.MODE_SMART: [220, 1, 3, 0, 1, 2, 1],
+        FountainAction.MODE_STANDARD: [220, 1, 3, 0, 1, 1, 1],
+        FountainAction.MODE_INTERMITTENT: [220, 1, 3, 0, 1, 2, 1],
+    }
+)
 
 
 async def async_setup_entry(

--- a/custom_components/petkit/const.py
+++ b/custom_components/petkit/const.py
@@ -112,7 +112,6 @@ MANUAL_FEED_OPT = {
 FOUNTAIN_WORKING_MODE_CTW3 = {
     1: "standard",
     2: "intermittent",
-    3: "battery",
 }
 
 FOUNTAIN_WORKING_MODE = {

--- a/custom_components/petkit/const.py
+++ b/custom_components/petkit/const.py
@@ -110,20 +110,20 @@ MANUAL_FEED_OPT = {
 }
 
 FOUNTAIN_WORKING_MODE_CTW3 = {
-    1: "Standard",
-    2: "Intermittent",
-    3: "Battery",
+    1: "standard",
+    2: "intermittent",
+    3: "battery",
 }
 
 FOUNTAIN_WORKING_MODE = {
-    1: "Normal",
-    2: "Smart",
+    1: "normal",
+    2: "smart",
 }
 
 LED_BRIGHTNESS = {
-    1: "Low",
-    2: "Normal",
-    3: "High",
+    1: "low",
+    2: "normal",
+    3: "high",
 }
 
 # Fan mode

--- a/custom_components/petkit/const.py
+++ b/custom_components/petkit/const.py
@@ -112,6 +112,7 @@ MANUAL_FEED_OPT = {
 FOUNTAIN_WORKING_MODE_CTW3 = {
     1: "standard",
     2: "intermittent",
+    3: "battery",
 }
 
 FOUNTAIN_WORKING_MODE = {

--- a/custom_components/petkit/select.py
+++ b/custom_components/petkit/select.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from pypetkitapi import (
+    CTW3,
     D4H,
     D4SH,
     T7,
@@ -17,13 +18,17 @@ from pypetkitapi import (
     Purifier,
     WaterFountain,
 )
+from pypetkitapi.command import FountainAction
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.const import EntityCategory
 
 from .const import (
     CLEANING_INTERVAL_OPT,
+    FOUNTAIN_WORKING_MODE,
+    FOUNTAIN_WORKING_MODE_CTW3,
     IA_DETECTION_SENSITIVITY_OPT,
+    LED_BRIGHTNESS,
     LITTER_TYPE_OPT,
     LOGGER,
     POWER_ONLINE_STATE,
@@ -63,6 +68,29 @@ async def _handle_surplus_control(api, device, opt_value):
             DeviceCommand.UPDATE_SETTING,
             {"surplusControl": 1, "surplusStandard": selected_key},
         )
+
+
+async def _handle_fountain_mode(api, device, opt_value):
+    """Change the working mode of a water fountain via BLE."""
+    device_type = getattr(device.device_nfo, "device_type", "").lower()
+    if device_type == CTW3:
+        mode_map = FOUNTAIN_WORKING_MODE_CTW3
+        action_map = {
+            1: FountainAction.MODE_STANDARD,
+            2: FountainAction.MODE_INTERMITTENT,
+        }
+    else:
+        mode_map = FOUNTAIN_WORKING_MODE
+        action_map = {
+            1: FountainAction.MODE_NORMAL,
+            2: FountainAction.MODE_SMART,
+        }
+    mode_int = next((k for k, v in mode_map.items() if v == opt_value), None)
+    if mode_int is None:
+        return
+    action = action_map.get(mode_int)
+    if action:
+        await api.bluetooth_manager.send_ble_command(device.id, action)
 
 
 COMMON_ENTITIES = []
@@ -188,7 +216,45 @@ SELECT_MAPPING: dict[type[PetkitDevices], list[PetKitSelectDesc]] = {
             entity_category=EntityCategory.CONFIG,
         ),
     ],
-    WaterFountain: [*COMMON_ENTITIES],
+    WaterFountain: [
+        *COMMON_ENTITIES,
+        PetKitSelectDesc(
+            key="Working mode",
+            translation_key="working_mode",
+            current_option=lambda device: FOUNTAIN_WORKING_MODE.get(device.mode),
+            options=lambda: list(FOUNTAIN_WORKING_MODE.values()),
+            action=_handle_fountain_mode,
+            entity_category=EntityCategory.CONFIG,
+            ignore_types=[CTW3],
+        ),
+        PetKitSelectDesc(
+            key="Working mode",
+            translation_key="working_mode",
+            current_option=lambda device: FOUNTAIN_WORKING_MODE_CTW3.get(device.mode),
+            options=lambda: list(FOUNTAIN_WORKING_MODE_CTW3.values()),
+            action=_handle_fountain_mode,
+            entity_category=EntityCategory.CONFIG,
+            only_for_types=[CTW3],
+        ),
+        PetKitSelectDesc(
+            key="Led brightness",
+            translation_key="led_brightness",
+            current_option=lambda device: LED_BRIGHTNESS.get(
+                device.settings.lamp_ring_brightness
+            ),
+            options=lambda: list(LED_BRIGHTNESS.values()),
+            action=lambda api, device, opt_value: api.send_api_request(
+                device.id,
+                DeviceCommand.UPDATE_SETTING,
+                {
+                    "lampRingBrightness": next(
+                        k for k, v in LED_BRIGHTNESS.items() if v == opt_value
+                    )
+                },
+            ),
+            entity_category=EntityCategory.CONFIG,
+        ),
+    ],
     Purifier: [*COMMON_ENTITIES],
     Pet: [*COMMON_ENTITIES],
 }

--- a/custom_components/petkit/select.py
+++ b/custom_components/petkit/select.py
@@ -91,6 +91,11 @@ async def _handle_fountain_mode(api, device, opt_value):
     action = action_map.get(mode_int)
     if action:
         await api.bluetooth_manager.send_ble_command(device.id, action)
+    else:
+        LOGGER.warning(
+            "Mode '%s' cannot be set manually on this device (read-only hardware state)",
+            opt_value,
+        )
 
 
 COMMON_ENTITIES = []
@@ -231,7 +236,9 @@ SELECT_MAPPING: dict[type[PetkitDevices], list[PetKitSelectDesc]] = {
             key="Working mode",
             translation_key="working_mode",
             current_option=lambda device: FOUNTAIN_WORKING_MODE_CTW3.get(device.mode),
-            options=lambda: list(FOUNTAIN_WORKING_MODE_CTW3.values()),
+            options=lambda: [
+                v for k, v in FOUNTAIN_WORKING_MODE_CTW3.items() if k != 3
+            ],
             action=_handle_fountain_mode,
             entity_category=EntityCategory.CONFIG,
             only_for_types=[CTW3],
@@ -253,6 +260,7 @@ SELECT_MAPPING: dict[type[PetkitDevices], list[PetKitSelectDesc]] = {
                 },
             ),
             entity_category=EntityCategory.CONFIG,
+            ignore_types=[CTW3],
         ),
     ],
     Purifier: [*COMMON_ENTITIES],

--- a/custom_components/petkit/switch.py
+++ b/custom_components/petkit/switch.py
@@ -836,9 +836,9 @@ SWITCH_MAPPING: dict[type[PetkitDevices], list[PetKitSwitchDesc]] = {
     WaterFountain: [
         *COMMON_ENTITIES,
         PetKitSwitchDesc(
-        key=INDICATOR_LIGHT,
-        translation_key="indicator_light",
-        value=lambda device: device.settings.lamp_ring_switch,
+            key=INDICATOR_LIGHT,
+            translation_key="indicator_light",
+            value=lambda device: device.settings.lamp_ring_switch,
             entity_category=EntityCategory.CONFIG,
             turn_on=lambda api, device: api.send_api_request(
                 device.id, DeviceCommand.UPDATE_SETTING, {"lampRingSwitch": 1}

--- a/custom_components/petkit/switch.py
+++ b/custom_components/petkit/switch.py
@@ -834,6 +834,30 @@ SWITCH_MAPPING: dict[type[PetkitDevices], list[PetKitSwitchDesc]] = {
     WaterFountain: [
         *COMMON_ENTITIES,
         PetKitSwitchDesc(
+            key="Indicator light",
+            translation_key="indicator_light",
+            value=lambda device: device.settings.lamp_ring_switch,
+            entity_category=EntityCategory.CONFIG,
+            turn_on=lambda api, device: api.send_api_request(
+                device.id, DeviceCommand.UPDATE_SETTING, {"lampRingSwitch": 1}
+            ),
+            turn_off=lambda api, device: api.send_api_request(
+                device.id, DeviceCommand.UPDATE_SETTING, {"lampRingSwitch": 0}
+            ),
+        ),
+        PetKitSwitchDesc(
+            key="Do not disturb",
+            translation_key="do_not_disturb",
+            value=lambda device: device.settings.no_disturbing_switch,
+            entity_category=EntityCategory.CONFIG,
+            turn_on=lambda api, device: api.send_api_request(
+                device.id, DeviceCommand.UPDATE_SETTING, {"noDisturbingSwitch": 1}
+            ),
+            turn_off=lambda api, device: api.send_api_request(
+                device.id, DeviceCommand.UPDATE_SETTING, {"noDisturbingSwitch": 0}
+            ),
+        ),
+        PetKitSwitchDesc(
             key="Power",
             translation_key="power",
             value=lambda device: (

--- a/custom_components/petkit/switch.py
+++ b/custom_components/petkit/switch.py
@@ -46,9 +46,11 @@ class PetKitSwitchDesc(PetKitDescSensorBase, SwitchEntityDescription):
     set_value: Callable[[Any, Any, Any], Any] | None = None
 
 
+INDICATOR_LIGHT = "Indicator light"
+
 COMMON_ENTITIES = [
     PetKitSwitchDesc(
-        key="Indicator light",
+        key=INDICATOR_LIGHT,
         translation_key="indicator_light",
         value=lambda device: device.settings.light_mode,
         entity_category=EntityCategory.CONFIG,
@@ -74,7 +76,7 @@ COMMON_ENTITIES = [
         only_for_types=DEVICES_LITTER_BOX,
     ),
     PetKitSwitchDesc(
-        key="Indicator light",
+        key=INDICATOR_LIGHT,
         translation_key="indicator_light",
         value=lambda device: device.settings.light_mode,
         entity_category=EntityCategory.CONFIG,
@@ -834,9 +836,9 @@ SWITCH_MAPPING: dict[type[PetkitDevices], list[PetKitSwitchDesc]] = {
     WaterFountain: [
         *COMMON_ENTITIES,
         PetKitSwitchDesc(
-            key="Indicator light",
-            translation_key="indicator_light",
-            value=lambda device: device.settings.lamp_ring_switch,
+        key=INDICATOR_LIGHT,
+        translation_key="indicator_light",
+        value=lambda device: device.settings.lamp_ring_switch,
             entity_category=EntityCategory.CONFIG,
             turn_on=lambda api, device: api.send_api_request(
                 device.id, DeviceCommand.UPDATE_SETTING, {"lampRingSwitch": 1}

--- a/custom_components/petkit/switch.py
+++ b/custom_components/petkit/switch.py
@@ -9,6 +9,7 @@ from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 from pypetkitapi import (
+    CTW3,
     DEVICES_LITTER_BOX,
     FEEDER_MINI,
     LITTER_WITH_CAMERA,
@@ -846,6 +847,7 @@ SWITCH_MAPPING: dict[type[PetkitDevices], list[PetKitSwitchDesc]] = {
             turn_off=lambda api, device: api.send_api_request(
                 device.id, DeviceCommand.UPDATE_SETTING, {"lampRingSwitch": 0}
             ),
+            ignore_types=[CTW3],
         ),
         PetKitSwitchDesc(
             key="Do not disturb",
@@ -858,6 +860,7 @@ SWITCH_MAPPING: dict[type[PetkitDevices], list[PetKitSwitchDesc]] = {
             turn_off=lambda api, device: api.send_api_request(
                 device.id, DeviceCommand.UPDATE_SETTING, {"noDisturbingSwitch": 0}
             ),
+            ignore_types=[CTW3],
         ),
         PetKitSwitchDesc(
             key="Power",

--- a/custom_components/petkit/translations/en.json
+++ b/custom_components/petkit/translations/en.json
@@ -268,8 +268,7 @@
           "normal": "Normal",
           "smart": "Smart",
           "standard": "Standard",
-          "intermittent": "Intermittent",
-          "battery": "Battery"
+          "intermittent": "Intermittent"
         }
       },
       "led_brightness": {

--- a/custom_components/petkit/translations/en.json
+++ b/custom_components/petkit/translations/en.json
@@ -263,10 +263,22 @@
         "name": "Litter type"
       },
       "working_mode": {
-        "name": "Working mode"
+        "name": "Working mode",
+        "state": {
+          "Normal": "Normal",
+          "Smart": "Smart",
+          "Standard": "Standard",
+          "Intermittent": "Intermittent",
+          "Battery": "Battery"
+        }
       },
       "led_brightness": {
-        "name": "Led brightness"
+        "name": "Led brightness",
+        "state": {
+          "Low": "Low",
+          "Normal": "Normal",
+          "High": "High"
+        }
       },
       "move_detection_sensitivity": {
         "name": "Move detection sensitivity"

--- a/custom_components/petkit/translations/en.json
+++ b/custom_components/petkit/translations/en.json
@@ -268,7 +268,8 @@
           "normal": "Normal",
           "smart": "Smart",
           "standard": "Standard",
-          "intermittent": "Intermittent"
+          "intermittent": "Intermittent",
+          "battery": "Battery"
         }
       },
       "led_brightness": {

--- a/custom_components/petkit/translations/en.json
+++ b/custom_components/petkit/translations/en.json
@@ -265,19 +265,19 @@
       "working_mode": {
         "name": "Working mode",
         "state": {
-          "Normal": "Normal",
-          "Smart": "Smart",
-          "Standard": "Standard",
-          "Intermittent": "Intermittent",
-          "Battery": "Battery"
+          "normal": "Normal",
+          "smart": "Smart",
+          "standard": "Standard",
+          "intermittent": "Intermittent",
+          "battery": "Battery"
         }
       },
       "led_brightness": {
         "name": "Led brightness",
         "state": {
-          "Low": "Low",
-          "Normal": "Normal",
-          "High": "High"
+          "low": "Low",
+          "normal": "Normal",
+          "high": "High"
         }
       },
       "move_detection_sensitivity": {

--- a/custom_components/petkit/translations/nl.json
+++ b/custom_components/petkit/translations/nl.json
@@ -263,10 +263,22 @@
         "name": "Strooiseltype"
       },
       "working_mode": {
-        "name": "Werkingsmodus"
+        "name": "Werkingsmodus",
+        "state": {
+          "Normal": "Normaal",
+          "Smart": "Slim",
+          "Standard": "Standaard",
+          "Intermittent": "Intermitterend",
+          "Battery": "Batterij"
+        }
       },
       "led_brightness": {
-        "name": "LED-helderheid"
+        "name": "LED-helderheid",
+        "state": {
+          "Low": "Laag",
+          "Normal": "Normaal",
+          "High": "Hoog"
+        }
       },
       "move_detection_sensitivity": {
         "name": "Bewegingsdetectiegevoeligheid"

--- a/custom_components/petkit/translations/nl.json
+++ b/custom_components/petkit/translations/nl.json
@@ -268,7 +268,8 @@
           "normal": "Normaal",
           "smart": "Slim",
           "standard": "Standaard",
-          "intermittent": "Intermitterend"
+          "intermittent": "Intermitterend",
+          "battery": "Batterij"
         }
       },
       "led_brightness": {

--- a/custom_components/petkit/translations/nl.json
+++ b/custom_components/petkit/translations/nl.json
@@ -265,19 +265,19 @@
       "working_mode": {
         "name": "Werkingsmodus",
         "state": {
-          "Normal": "Normaal",
-          "Smart": "Slim",
-          "Standard": "Standaard",
-          "Intermittent": "Intermitterend",
-          "Battery": "Batterij"
+          "normal": "Normaal",
+          "smart": "Slim",
+          "standard": "Standaard",
+          "intermittent": "Intermitterend",
+          "battery": "Batterij"
         }
       },
       "led_brightness": {
         "name": "LED-helderheid",
         "state": {
-          "Low": "Laag",
-          "Normal": "Normaal",
-          "High": "Hoog"
+          "low": "Laag",
+          "normal": "Normaal",
+          "high": "Hoog"
         }
       },
       "move_detection_sensitivity": {

--- a/custom_components/petkit/translations/nl.json
+++ b/custom_components/petkit/translations/nl.json
@@ -268,8 +268,7 @@
           "normal": "Normaal",
           "smart": "Slim",
           "standard": "Standaard",
-          "intermittent": "Intermitterend",
-          "battery": "Batterij"
+          "intermittent": "Intermitterend"
         }
       },
       "led_brightness": {

--- a/custom_components/petkit/translations/uk.json
+++ b/custom_components/petkit/translations/uk.json
@@ -268,8 +268,7 @@
           "normal": "Нормальний",
           "smart": "Розумний",
           "standard": "Стандартний",
-          "intermittent": "Переривчастий",
-          "battery": "Акумулятор"
+          "intermittent": "Переривчастий"
         }
       },
       "led_brightness": {

--- a/custom_components/petkit/translations/uk.json
+++ b/custom_components/petkit/translations/uk.json
@@ -263,10 +263,22 @@
         "name": "Тип наповнювача"
       },
       "working_mode": {
-        "name": "Режим роботи"
+        "name": "Режим роботи",
+        "state": {
+          "Normal": "Нормальний",
+          "Smart": "Розумний",
+          "Standard": "Стандартний",
+          "Intermittent": "Переривчастий",
+          "Battery": "Акумулятор"
+        }
       },
       "led_brightness": {
-        "name": "Яскравість LED"
+        "name": "Яскравість LED",
+        "state": {
+          "Low": "Низька",
+          "Normal": "Нормальна",
+          "High": "Висока"
+        }
       },
       "move_detection_sensitivity": {
         "name": "Чутливість виявлення руху"

--- a/custom_components/petkit/translations/uk.json
+++ b/custom_components/petkit/translations/uk.json
@@ -268,7 +268,8 @@
           "normal": "Нормальний",
           "smart": "Розумний",
           "standard": "Стандартний",
-          "intermittent": "Переривчастий"
+          "intermittent": "Переривчастий",
+          "battery": "Батарея"
         }
       },
       "led_brightness": {

--- a/custom_components/petkit/translations/uk.json
+++ b/custom_components/petkit/translations/uk.json
@@ -265,19 +265,19 @@
       "working_mode": {
         "name": "Режим роботи",
         "state": {
-          "Normal": "Нормальний",
-          "Smart": "Розумний",
-          "Standard": "Стандартний",
-          "Intermittent": "Переривчастий",
-          "Battery": "Акумулятор"
+          "normal": "Нормальний",
+          "smart": "Розумний",
+          "standard": "Стандартний",
+          "intermittent": "Переривчастий",
+          "battery": "Акумулятор"
         }
       },
       "led_brightness": {
         "name": "Яскравість LED",
         "state": {
-          "Low": "Низька",
-          "Normal": "Нормальна",
-          "High": "Висока"
+          "low": "Низька",
+          "normal": "Нормальна",
+          "high": "Висока"
         }
       },
       "move_detection_sensitivity": {


### PR DESCRIPTION
## Summary

Implements missing controls for water fountain devices requested in #94.

## New entities

| Entity | Type | Device | How |
|---|---|---|---|
| Working mode | Select | W4/W5/CTW2 (Normal/Smart) | BLE CMD 220 |
| Working mode | Select | CTW3 (Standard/Intermittent) | BLE CMD 220 |
| Led brightness | Select | All fountains (Low/Normal/High) | REST API |
| Indicator light | Switch | All fountains | REST API |
| Do not disturb | Switch | All fountains | REST API |

## Technical notes

### Working mode via BLE
pypetkitapi's FOUNTAIN_COMMAND dict was missing byte sequences for MODE_NORMAL, MODE_SMART, MODE_STANDARD, and MODE_INTERMITTENT. The sequences follow the same CMD 220 frame format as the existing POWER_ON/POWER_OFF entries and are derived from the W5BLEMQTT project:

cmd=220, type=1, data=[state=1, mode_byte, op_type=1]

These are patched into FOUNTAIN_COMMAND at integration startup in __init__.py until they can be upstreamed to pypetkitapi.

### LED brightness / DND / Indicator light
These settings use UPDATE_SETTING with the correct camelCase field names (lampRingBrightness, lampRingSwitch, noDisturbingSwitch). The fountain-specific noDisturbingSwitch replaces the generic disturbMode key used by other device types.

### Translations
State labels for the new select entities added to en, nl, and uk.


## Follow-up fixes (addressing review feedback)

- **Battery mode restored** (const.py): FOUNTAIN_WORKING_MODE_CTW3 now includes 3: 'battery' again. Battery mode is displayed as current state when device reports it, but excluded from selectable options (hardware-managed state, not user-settable). Selecting it logs a warning instead of silently failing.
- **404 on CTW3 for updateSettings** (switch.py, select.py): Indicator light, Do not disturb, and LED brightness now have ignore_types=[CTW3] - these REST API endpoints return 404 on CTW3. CTW3 controls LED and DND via BLE (future work).
- **Translations**: Added 'battery' state to working_mode in en.json, nl.json, uk.json.