### PR TITLE
fix: suppress google-crc32c RuntimeWarning on HA startup (issue #184)

### DIFF
--- a/custom_components/petkit/whep_mirror.py
+++ b/custom_components/petkit/whep_mirror.py
@@ -30,7 +30,9 @@ try:
     # a pure-Python implementation. Suppress it here — it is harmless (streaming
     # continues to work) and would otherwise pollute the HA log on every startup.
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=RuntimeWarning, module="google_crc32c")
+        warnings.filterwarnings(
+            "ignore", category=RuntimeWarning, module="google_crc32c"
+        )
         from aiortc import (
             RTCConfiguration,
             RTCIceServer as AiortcIceServer,

--- a/custom_components/petkit/whep_mirror.py
+++ b/custom_components/petkit/whep_mirror.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 import ipaddress
 import secrets
 from typing import TYPE_CHECKING, Any
+import warnings
 
 from aiohttp import web
 
@@ -24,15 +25,21 @@ from .webrtc_common import (
 )
 
 try:
-    from aiortc import (
-        RTCConfiguration,
-        RTCIceServer as AiortcIceServer,
-        RTCPeerConnection,
-        RTCRtpSender,
-        RTCSessionDescription,
-    )
-    from aiortc.contrib.media import MediaRelay
-    from aiortc.sdp import candidate_from_sdp
+    # google-crc32c (pulled in by aiortc) emits a RuntimeWarning when its native
+    # C extension is unavailable in the HA Docker environment and falls back to
+    # a pure-Python implementation. Suppress it here — it is harmless (streaming
+    # continues to work) and would otherwise pollute the HA log on every startup.
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=RuntimeWarning, module="google_crc32c")
+        from aiortc import (
+            RTCConfiguration,
+            RTCIceServer as AiortcIceServer,
+            RTCPeerConnection,
+            RTCRtpSender,
+            RTCSessionDescription,
+        )
+        from aiortc.contrib.media import MediaRelay
+        from aiortc.sdp import candidate_from_sdp
 except Exception as err:  # noqa: BLE001
     RTCConfiguration = None
     AiortcIceServer = None

--- a/custom_components/petkit/whep_mirror.py
+++ b/custom_components/petkit/whep_mirror.py
@@ -27,11 +27,14 @@ from .webrtc_common import (
 try:
     # google-crc32c (pulled in by aiortc) emits a RuntimeWarning when its native
     # C extension is unavailable in the HA Docker environment and falls back to
-    # a pure-Python implementation. Suppress it here — it is harmless (streaming
-    # continues to work) and would otherwise pollute the HA log on every startup.
+    # a pure-Python implementation. Suppress only that known harmless warning
+    # here so unexpected RuntimeWarnings from the same module remain visible.
     with warnings.catch_warnings():
         warnings.filterwarnings(
-            "ignore", category=RuntimeWarning, module="google_crc32c"
+            "ignore",
+            message=r".*(?:pure[- ]Python implementation|using a python implementation).*",
+            category=RuntimeWarning,
+            module=r"^google_crc32c(?:\..+)?$",
         )
         from aiortc import (
             RTCConfiguration,


### PR DESCRIPTION
## Summary

Fixes #184

`aiortc` (used for camera streaming) depends on `google-crc32c`, which emits a `RuntimeWarning` on every HA startup when its native C extension is unavailable in the HA Docker environment. The warning is harmless — streaming continues to work via the pure-Python fallback — but it pollutes the HA log on every startup.

## Fix

Wrap the aiortc import block in `whep_mirror.py` with `warnings.catch_warnings()` that filters RuntimeWarning from the `google_crc32c` module during import. No functional changes — only log noise is suppressed.

> **Note:** PR #205 was previously closed. This is the cleaned-up version containing only the `whep_mirror.py` change as requested.