### PR TITLE
docs: clarify config flow account-setup description

### DIFF
--- a/custom_components/petkit/config_flow.py
+++ b/custom_components/petkit/config_flow.py
@@ -316,6 +316,9 @@ class PetkitFlowHandler(ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=vol.Schema(data_schema),
             errors=_errors,
+            description_placeholders={
+                "wiki_url": "https://github.com/Jezza34000/homeassistant_petkit/wiki/Configuration"
+            },
         )
 
     async def _test_credentials(

--- a/custom_components/petkit/translations/en.json
+++ b/custom_components/petkit/translations/en.json
@@ -18,7 +18,7 @@
           "time_zone": "This field is automatically completed based on your Home Assistant configuration. If you have a different timezone, please select it from the list.",
           "username": "Enter your PetKit account email, or id if you are a Chinese user"
         },
-        "description": "Please enter your PetKit account details. DO NOT use the same account that you use in the PetKit app on your smartphone. Refer to the documentation for more information."
+        "description": "Enter the PetKit account that Home Assistant will use to talk to PetKit's cloud.\n\n**Important:** this must be a *separate* PetKit account from the one you sign in to the mobile app with. PetKit only allows one active session per account, so signing in here with your main account will log you out of the app (and vice versa).\n\n**Setup:**\n1. Create a second PetKit account (different email).\n2. In the PetKit mobile app, signed in as your main account, open **Family Management** and create a family.\n3. Invite the second account as a family member and accept the invite.\n4. Enter the second account's credentials below.\n\nFull guide: [Configuration wiki](https://github.com/Jezza34000/homeassistant_petkit/wiki/Configuration)."
       }
     }
   },

--- a/custom_components/petkit/translations/en.json
+++ b/custom_components/petkit/translations/en.json
@@ -18,7 +18,7 @@
           "time_zone": "This field is automatically completed based on your Home Assistant configuration. If you have a different timezone, please select it from the list.",
           "username": "Enter your PetKit account email, or id if you are a Chinese user"
         },
-        "description": "Enter the PetKit account that Home Assistant will use to talk to PetKit's cloud.\n\n**Important:** this must be a *separate* PetKit account from the one you sign in to the mobile app with. PetKit only allows one active session per account, so signing in here with your main account will log you out of the app (and vice versa).\n\n**Setup:**\n1. Create a second PetKit account (different email).\n2. In the PetKit mobile app, signed in as your main account, open **Family Management** and create a family.\n3. Invite the second account as a family member and accept the invite.\n4. Enter the second account's credentials below.\n\nFull guide: [Configuration wiki](https://github.com/Jezza34000/homeassistant_petkit/wiki/Configuration)."
+        "description": "Enter the PetKit account that Home Assistant will use to talk to PetKit's cloud.\n\n**Important:** this must be a *separate* PetKit account from the one you sign in to the mobile app with. PetKit only allows one active session per account, so signing in here with your main account will log you out of the app (and vice versa).\n\n**Setup:**\n1. Create a second PetKit account (different email).\n2. In the PetKit mobile app, signed in as your main account, open **Family Management** and create a family.\n3. Invite the second account as a family member and accept the invite.\n4. Enter the second account's credentials below.\n\nFull guide: [Configuration wiki]({wiki_url})."
       }
     }
   },


### PR DESCRIPTION
## 📝 Proposed Change / Description

When installing the integration, the only guidance shown in the config flow is:

> Please enter your PetKit account details. DO NOT use the same account that you use in the PetKit app on your smartphone. Refer to the documentation for more information.

That tells the user what not to do, but not why, how, or where the documentation lives. As a fresh installer my reaction was "I made a new account on petkit.com, now what?". There's no path forward without already knowing about Family Management.

This PR rewrites the description to:

1. State why a separate account is needed (PetKit only allows one active session per account, so signing in with the app account here logs you out of the app, and vice versa).
2. Give a concrete 4-step setup: create second account, Family Management, invite, enter here.
3. Link directly to the [Configuration wiki page](https://github.com/Jezza34000/homeassistant_petkit/wiki/Configuration) for the full guide.

Home Assistant renders markdown in step descriptions, so the bold/italic/list/link formatting renders in the UI.

Only `custom_components/petkit/translations/en.json` is touched (`config.step.user.description`). Other locales pick up the new English source via Weblate as usual.

### Before

> Please enter your PetKit account details. DO NOT use the same account that you use in the PetKit app on your smartphone. Refer to the documentation for more information.

### After (rendered in HA)

> **Enter the PetKit account that Home Assistant will use to talk to PetKit's cloud.**
>
> **Important:** this must be a *separate* PetKit account from the one you sign in to the mobile app with. PetKit only allows one active session per account, so signing in here with your main account will log you out of the app (and vice versa).
>
> **Setup:**
> 1. Create a second PetKit account (different email).
> 2. In the PetKit mobile app, signed in as your main account, open **Family Management** and create a family.
> 3. Invite the second account as a family member and accept the invite.
> 4. Enter the second account's credentials below.
>
> Full guide: [Configuration wiki](https://github.com/Jezza34000/homeassistant_petkit/wiki/Configuration).

**Fixes:** n/a

---

## 🔖 Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔧 Refactor / code cleanup (no functional change)
- [x] 📚 Documentation update
- [ ] 🔒 Security fix
- [ ] ⬆️ Dependency update

---

## 🐾 Affected devices

- [x] 🌐 All devices

**Specific type:**

- [ ] Litter boxes : ()
- [ ] Feeders : ()
- [ ] Fountains : ()
- [ ] Purifiers : ()

**Specific category :**

- [ ] Cameras devices : ()
- [ ] Non camera devices : ()
- [ ] BLE only devices : ()

---

## 🧪 How has this been tested?

- [ ] Tested locally with a real PetKit device
- [ ] Tested with Home Assistant version:
- [x] No testing required (docs, CI config, etc.)

JSON validity verified with `python -m json.tool`. Text-only change inside an existing translation key, no runtime behaviour affected.

**Device(s) tested on:**

N/A. Translation string change only.

**Other devices you own when the test was done:**

N/A.

---

## ✅ Checklist

- [ ] Code follows project style : `pre-commit run -a` hooks and all checks pass
- [x] No new linting/type errors introduced
- [x] Documentation updated (if needed)
- [x] Branch is up-to-date with `main`

I did not run `pre-commit run -a` locally. Happy to run it and push a follow-up if a hook flags anything.

---

## 📸 Screenshots / Logs (optional)

<img width="1160" height="1372" alt="bilde" src="https://github.com/user-attachments/assets/a181775e-5f48-4e2b-a7f7-e31fbe193d55" />

---

## ℹ️ Additional context

- Original wording made it unclear that a second account alone isn't enough. The user must also share devices via Family Management.
- Markdown (`**bold**`, `*italic*`, ordered list, `[link](url)`) is supported in HA `description` strings, so no schema change is needed.

---

## ⚠️ Breaking Changes

- [x] No breaking changes.
- [ ] **Warning:** This PR introduces breaking changes.

**Description of changes:**

N/A.

---

## Thanks for the helping paw! 🐾