### PR TITLE
feat(blueprints): add fountain drink counter, anomaly alerts, and stats package

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
       - id: check-ast
       - id: check-toml
       - id: check-yaml
+        exclude: ^blueprints/
       - id: debug-statements
       - id: check-case-conflict
       - id: end-of-file-fixer

--- a/blueprints/automation/petkit/README.md
+++ b/blueprints/automation/petkit/README.md
@@ -1,0 +1,21 @@
+# PetKit blueprints
+
+| Blueprint                         | What it does                                                                                                      |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `fountain_drink_counter.yaml`     | Increments a counter on each off-to-on transition of the `Pet drinking` binary sensor, with optional daily reset. |
+| `fountain_no_drinks_alert.yaml`   | Fires when the binary sensor has stayed `off` for X hours.                                                        |
+| `fountain_low_drinks_alert.yaml`  | Fires once a day if today's count is below a percentage of the 7-day median.                                      |
+| `fountain_high_drinks_alert.yaml` | Fires once a day if today's count is above a percentage of the 7-day median.                                      |
+
+The alert blueprints depend on the counter blueprint and the companion
+package YAML. See [`docs/automations.md`](../../../docs/automations.md) for
+the full setup.
+
+### Import
+
+In Home Assistant: **Settings → Automations & Scenes → Blueprints →
+Import Blueprint**, and paste the raw URL for the blueprint you want, e.g.:
+
+```
+https://github.com/Jezza34000/homeassistant_petkit/blob/main/blueprints/automation/petkit/fountain_drink_counter.yaml
+```

--- a/blueprints/automation/petkit/fountain_drink_counter.yaml
+++ b/blueprints/automation/petkit/fountain_drink_counter.yaml
@@ -1,0 +1,94 @@
+blueprint:
+  name: "PetKit fountain: drink counter"
+  description: >
+    Increments a counter each time the fountain detects a pet drinking, with
+    an optional daily reset. Lets you keep a local drink history without
+    relying on PetKit's cloud aggregates.
+
+
+    **Setup**
+
+
+    1. Create a Counter helper: Settings → Devices & services → Helpers →
+    Create helper → Counter. Suggested name: `Fountain drinks today`. Leave
+    *Initial value* at 0 and *Step* at 1.
+
+    2. Import this blueprint, then create an automation from it. Pick your
+    fountain's *Pet drinking* binary sensor and the counter you just created.
+
+
+    **Weekly / monthly totals (optional)**
+
+
+    Add a Utility Meter helper (cycle: weekly / monthly) with the counter
+    as its source. Leave *Reset at midnight* enabled. The counter resets
+    daily, the utility meter records the running totals.
+  domain: automation
+  source_url: https://github.com/Jezza34000/homeassistant_petkit/blob/main/blueprints/automation/petkit/fountain_drink_counter.yaml
+  input:
+    pet_drinking_sensor:
+      name: Pet drinking sensor
+      description: >
+        The fountain's "Pet drinking" binary sensor (device class:
+        occupancy). One drink event = one off→on transition.
+      selector:
+        entity:
+          filter:
+            - domain: binary_sensor
+              device_class: occupancy
+    drinks_counter:
+      name: Drinks counter
+      description: A Counter helper that will be incremented on each drink event.
+      selector:
+        entity:
+          filter:
+            - domain: counter
+    reset_at_midnight:
+      name: Reset counter daily
+      description: >
+        If enabled, the counter resets to 0 at the time below. Disable if
+        you handle resets via a Utility Meter instead.
+      default: true
+      selector:
+        boolean:
+    reset_time:
+      name: Reset time
+      description: When the daily reset runs. Ignored if the reset is disabled.
+      default: "00:00:00"
+      selector:
+        time:
+
+mode: parallel
+max_exceeded: silent
+
+variables:
+  reset_enabled: !input reset_at_midnight
+
+trigger:
+  - platform: state
+    entity_id: !input pet_drinking_sensor
+    from: "off"
+    to: "on"
+    id: drink
+  - platform: time
+    at: !input reset_time
+    id: reset
+
+action:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id: drink
+        sequence:
+          - service: counter.increment
+            target:
+              entity_id: !input drinks_counter
+      - conditions:
+          - condition: trigger
+            id: reset
+          - condition: template
+            value_template: "{{ reset_enabled }}"
+        sequence:
+          - service: counter.reset
+            target:
+              entity_id: !input drinks_counter

--- a/blueprints/automation/petkit/fountain_high_drinks_alert.yaml
+++ b/blueprints/automation/petkit/fountain_high_drinks_alert.yaml
@@ -1,0 +1,78 @@
+blueprint:
+  name: "PetKit fountain: high drinks alert"
+  description: >
+    Fires once a day at the configured check time if today's drink count is
+    above a percentage of the 7-day median. Higher-than-usual intake can
+    indicate heat stress, illness, or simply fresh water. Useful as an early
+    signal worth investigating.
+
+
+    Requires the package's median sensor (default
+    `sensor.petkit_fountain_drinks_median`). The first 7 days are a
+    calibration period; alerts will be noisy or wrong until enough history
+    is collected.
+  domain: automation
+  source_url: https://github.com/Jezza34000/homeassistant_petkit/blob/main/blueprints/automation/petkit/fountain_high_drinks_alert.yaml
+  input:
+    drinks_today_sensor:
+      name: Drinks today sensor
+      description: Sensor tracking today's drink count.
+      default: sensor.petkit_fountain_drinks_today
+      selector:
+        entity:
+          filter:
+            - domain: sensor
+    median_sensor:
+      name: 7-day median sensor
+      description: Statistics sensor with the 7-day drink-count median.
+      default: sensor.petkit_fountain_drinks_median
+      selector:
+        entity:
+          filter:
+            - domain: sensor
+    threshold_pct:
+      name: Threshold (% of median)
+      description: Trigger if today's count is above this percentage of the median.
+      default: 200
+      selector:
+        number:
+          min: 110
+          max: 500
+          step: 10
+          unit_of_measurement: "%"
+    check_time:
+      name: Check time
+      description: Time of day to evaluate. Defaults to 20:00, late enough that most of the day's drinking pattern is clear.
+      default: "20:00:00"
+      selector:
+        time:
+    alert_action:
+      name: Action
+      description: What to do when the alert fires.
+      default:
+        - service: persistent_notification.create
+          data:
+            title: "Fountain: high drinks today"
+            message: "Today's drink count is well above the 7-day median. Check for heat or illness."
+      selector:
+        action:
+
+mode: single
+
+variables:
+  drinks_today_sensor: !input drinks_today_sensor
+  median_sensor: !input median_sensor
+  threshold_pct: !input threshold_pct
+
+trigger:
+  - platform: time
+    at: !input check_time
+
+condition:
+  - condition: template
+    value_template: >
+      {% set today = states(drinks_today_sensor) | float(0) %}
+      {% set median = states(median_sensor) | float(0) %}
+      {{ median > 0 and (today / median * 100) > threshold_pct }}
+
+action: !input alert_action

--- a/blueprints/automation/petkit/fountain_low_drinks_alert.yaml
+++ b/blueprints/automation/petkit/fountain_low_drinks_alert.yaml
@@ -1,0 +1,77 @@
+blueprint:
+  name: "PetKit fountain: low drinks alert"
+  description: >
+    Fires once a day at the configured check time if today's drink count is
+    below a percentage of the 7-day median. Useful for catching reduced water
+    intake before it becomes serious.
+
+
+    Requires the package's median sensor (default
+    `sensor.petkit_fountain_drinks_median`). The first 7 days are a
+    calibration period; alerts will be noisy or wrong until enough history
+    is collected.
+  domain: automation
+  source_url: https://github.com/Jezza34000/homeassistant_petkit/blob/main/blueprints/automation/petkit/fountain_low_drinks_alert.yaml
+  input:
+    drinks_today_sensor:
+      name: Drinks today sensor
+      description: Sensor tracking today's drink count.
+      default: sensor.petkit_fountain_drinks_today
+      selector:
+        entity:
+          filter:
+            - domain: sensor
+    median_sensor:
+      name: 7-day median sensor
+      description: Statistics sensor with the 7-day drink-count median.
+      default: sensor.petkit_fountain_drinks_median
+      selector:
+        entity:
+          filter:
+            - domain: sensor
+    threshold_pct:
+      name: Threshold (% of median)
+      description: Trigger if today's count is below this percentage of the median.
+      default: 30
+      selector:
+        number:
+          min: 5
+          max: 95
+          step: 5
+          unit_of_measurement: "%"
+    check_time:
+      name: Check time
+      description: Time of day to evaluate. Defaults to 20:00, late enough that most drinking has happened.
+      default: "20:00:00"
+      selector:
+        time:
+    alert_action:
+      name: Action
+      description: What to do when the alert fires.
+      default:
+        - service: persistent_notification.create
+          data:
+            title: "Fountain: low drinks today"
+            message: "Today's drink count is well below the 7-day median. Worth checking on the pet."
+      selector:
+        action:
+
+mode: single
+
+variables:
+  drinks_today_sensor: !input drinks_today_sensor
+  median_sensor: !input median_sensor
+  threshold_pct: !input threshold_pct
+
+trigger:
+  - platform: time
+    at: !input check_time
+
+condition:
+  - condition: template
+    value_template: >
+      {% set today = states(drinks_today_sensor) | float(0) %}
+      {% set median = states(median_sensor) | float(0) %}
+      {{ median > 0 and (today / median * 100) < threshold_pct }}
+
+action: !input alert_action

--- a/blueprints/automation/petkit/fountain_no_drinks_alert.yaml
+++ b/blueprints/automation/petkit/fountain_no_drinks_alert.yaml
@@ -1,0 +1,52 @@
+blueprint:
+  name: "PetKit fountain: no drinks alert"
+  description: >
+    Fires when the fountain's *Pet drinking* binary sensor has stayed `off`
+    continuously for the configured number of hours. Useful for catching a
+    pet who has stopped drinking.
+
+
+    Pick what should happen via the *Action* input. Defaults to a persistent
+    notification in HA.
+  domain: automation
+  source_url: https://github.com/Jezza34000/homeassistant_petkit/blob/main/blueprints/automation/petkit/fountain_no_drinks_alert.yaml
+  input:
+    pet_drinking_sensor:
+      name: Pet drinking sensor
+      description: The fountain's "Pet drinking" binary sensor.
+      selector:
+        entity:
+          filter:
+            - domain: binary_sensor
+              device_class: occupancy
+    hours_threshold:
+      name: Hours without drinking
+      description: How long the sensor must stay `off` before the alert fires.
+      default: 12
+      selector:
+        number:
+          min: 1
+          max: 48
+          step: 1
+          unit_of_measurement: h
+    alert_action:
+      name: Action
+      description: What to do when the alert fires.
+      default:
+        - service: persistent_notification.create
+          data:
+            title: "Fountain: no drinks detected"
+            message: "Pet hasn't been at the fountain for the configured threshold. Worth checking on them."
+      selector:
+        action:
+
+mode: single
+
+trigger:
+  - platform: state
+    entity_id: !input pet_drinking_sensor
+    to: "off"
+    for:
+      hours: !input hours_threshold
+
+action: !input alert_action

--- a/docs/automations.md
+++ b/docs/automations.md
@@ -1,0 +1,194 @@
+# Local automations and stats
+
+Recipes that complement the integration with locally-computed drink history,
+trends, and daily/weekly/monthly stats. Useful in particular if you run with
+local BLE polling and want a setup that survives without the PetKit cloud.
+
+The integration already exposes today's pump runtime, battery, filter %, and
+a `Pet drinking` binary sensor. What's missing is the per-day/week/month
+aggregates that the PetKit app shows. The blueprint and package below add
+those.
+
+---
+
+## Quick start: daily drink count only
+
+If you just want a "drinks today" counter and don't care about weekly /
+monthly trends:
+
+1. Create a Counter helper: **Settings → Devices & services → Helpers →
+   Create helper → Counter**. Name it `Fountain drinks today`.
+2. Import the blueprint:
+
+   ```
+   https://github.com/Jezza34000/homeassistant_petkit/blob/main/blueprints/automation/petkit/fountain_drink_counter.yaml
+   ```
+
+3. Create an automation from it. Pick your fountain's _Pet drinking_ binary
+   sensor, the counter you just made, and leave **Reset counter daily**
+   enabled.
+
+Done. The counter increments on every drink event and resets at midnight.
+
+---
+
+## Full app parity
+
+This setup mirrors what the PetKit app shows on the fountain page (drinks today / week / month plus drink-time today and this week), entirely locally. Three companion blueprints add anomaly alerts on top.
+
+### What you get
+
+| Entity                                        | What it shows                                                                          |
+| --------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `counter.petkit_fountain_drinks_total`        | Lifetime drinks since the package was added. Source of truth.                          |
+| `sensor.petkit_fountain_drinks_today`         | Drinks today (resets at local midnight).                                               |
+| `sensor.petkit_fountain_drinks_this_week`     | Drinks since Monday 00:00.                                                             |
+| `sensor.petkit_fountain_drinks_this_month`    | Drinks since the 1st 00:00.                                                            |
+| `sensor.petkit_fountain_drink_time_today`     | Total time the pet was drinking today.                                                 |
+| `sensor.petkit_fountain_drink_time_this_week` | Drink time since Monday 00:00.                                                         |
+| `sensor.petkit_fountain_drinks_final_today`   | Daily snapshot of today's count at 23:55. Used as a stable input to the median sensor. |
+| `sensor.petkit_fountain_drinks_median`        | 7-day median of daily drink counts. Used by the anomaly-alert blueprints.              |
+
+The integration already gives you `sensor.<fountain>_today_pump_run_time`
+(BLE-reported, firmware-side), so you can compare HA's count to the
+firmware's runtime if you want to spot polling gaps.
+
+### Setup
+
+1. Enable packages in `configuration.yaml` if you haven't already:
+
+   ```yaml
+   homeassistant:
+     packages: !include_dir_named packages
+   ```
+
+2. Copy [`docs/examples/petkit_fountain_stats.yaml`][pkg] into
+   `<config>/packages/petkit_fountain_stats.yaml`.
+
+3. Edit the file: replace `binary_sensor.REPLACE_ME_pet_drinking` with your
+   fountain's actual entity id (twice, both `history_stats` blocks).
+
+4. Restart Home Assistant. The counter, utility meters, history_stats
+   sensors, and the daily snapshot + 7-day median sensor will all appear.
+
+5. Import the blueprint and create an automation:
+   - **Pet drinking sensor**: your fountain's binary sensor.
+   - **Drinks counter**: `counter.petkit_fountain_drinks_total`.
+   - **Reset counter daily**: **OFF**. The utility meters handle the
+     cycles. Leaving this on would zero the counter every night and break
+     the weekly/monthly meters.
+
+[pkg]: examples/petkit_fountain_stats.yaml
+
+### How it fits together
+
+```
+binary_sensor.<fountain>_pet_drinking
+    │
+    ├─→ (drink-counter blueprint) ─→ counter.petkit_fountain_drinks_total ─┐
+    │                                                                       │
+    │                                    ┌──────────────────────────────────┤
+    │                                    ↓                                  ↓
+    │                       utility_meter (daily/weekly/monthly)            │
+    │                                    │                                  │
+    │                                    │  daily (sensor.*_drinks_today)   │
+    │                                    ↓                                  │
+    │                       trigger-template snapshot at 23:55              │
+    │                                    │                                  │
+    │                                    ↓                                  │
+    │                       statistics sensor (7-day median) ←──────────────┘
+    │                                    │
+    │                                    ↓
+    │                       fountain_*_drinks_alert blueprints
+    │
+    └─→ history_stats (drink time today / this week)
+```
+
+### Anomaly alerts
+
+Three optional blueprints sit on top of the package. Each is a self-contained
+automation that calls a notification action (or any action you pick) when the
+fountain's drink pattern looks off.
+
+| Blueprint                    | Default trigger                                            | Useful for                                  |
+| ---------------------------- | ---------------------------------------------------------- | ------------------------------------------- |
+| `fountain_no_drinks_alert`   | `Pet drinking` stayed `off` for 12h continuously.          | Catching a pet that has stopped drinking.   |
+| `fountain_low_drinks_alert`  | At 20:00, today's count is below 30% of the 7-day median.  | Reduced intake before it becomes serious.   |
+| `fountain_high_drinks_alert` | At 20:00, today's count is above 200% of the 7-day median. | Heat stress, illness, or fresh-water spike. |
+
+Each blueprint exposes its threshold and check time as inputs. Defaults are
+ballpark guesses meant for a single-cat household. Adjust to fit yours.
+
+#### Calibration period
+
+The low/high alerts compare today's count to a 7-day median. Until you have
+7 days of data the median is unstable, so those alerts will be noisy or wrong
+during the first week. The "no drinks" alert works from day one since it only
+needs the binary sensor.
+
+#### Setup
+
+For each alert you want:
+
+1. Settings → Automations & Scenes → Blueprints. Import:
+
+   ```
+   https://github.com/Jezza34000/homeassistant_petkit/blob/main/blueprints/automation/petkit/fountain_no_drinks_alert.yaml
+   https://github.com/Jezza34000/homeassistant_petkit/blob/main/blueprints/automation/petkit/fountain_low_drinks_alert.yaml
+   https://github.com/Jezza34000/homeassistant_petkit/blob/main/blueprints/automation/petkit/fountain_high_drinks_alert.yaml
+   ```
+
+2. Create an automation from each. The default action is a persistent
+   notification in HA. Replace it with `notify.mobile_app_<your_phone>` or
+   any other action via the UI.
+
+3. For low/high alerts, the defaults already point at
+   `sensor.petkit_fountain_drinks_today` and
+   `sensor.petkit_fountain_drinks_median` from the package. If you have
+   multiple fountains, point each automation at its respective sensors.
+
+#### Notes
+
+- Each alert fires at most once per check (single mode), so the time-of-day
+  alerts can fire at most once per day.
+- The "no drinks" alert resets each time the binary sensor goes back to `on`,
+  so a single drink event during the day cancels the timer.
+- These are intended as informational nudges, not medical guidance. False
+  positives happen, especially during the calibration period and on travel
+  days when the household pattern changes.
+
+### Multiple fountains
+
+The package and blueprint are written for a single fountain. For a second
+one, duplicate the package file with a different name prefix (e.g.
+`petkit_fountain2_stats.yaml`, rename all entity ids to `..._fountain2_..`),
+and create a second automation from the same blueprint pointing at the
+new counter and binary sensor.
+
+### Troubleshooting
+
+**Counter doesn't increment.** Check that your fountain's `Pet drinking`
+binary sensor actually toggles when the pet drinks. If it stays `off`, the
+issue is upstream of the automation: the integration isn't getting drink
+events. Local BLE polling needs to be working, or cloud-relay (with
+another PetKit device in the family) needs to be available.
+
+**`utility_meter` shows 0 forever.** The source counter has to _change_ for
+the utility meter to record anything. Confirm `counter.petkit_fountain_drinks_total`
+is incrementing first. If you previously had the daily reset enabled in the
+blueprint, the utility meters may have been confused by the counter going
+backwards. Disable the reset, then restart Home Assistant to re-initialize
+the meters.
+
+**Drink time today is stuck.** The `history_stats` `start` template only
+re-evaluates on a state change of the source binary sensor. If your pet
+drinks once at 03:00 and never again that day, the sensor will keep
+showing that one event's contribution until midnight rolls over and a new
+drink happens. This is `history_stats` working as designed; the displayed
+total is correct, just sticky between events.
+
+**Median sensor is `unknown`.** The 7-day median sensor is fed by the
+trigger-template snapshot, which only fires at 23:55 each day. So the
+median stays `unknown` until at least one snapshot has been recorded
+(i.e., the day after you install the package). Low/high alerts won't
+fire while the median is `unknown`.

--- a/docs/examples/petkit_fountain_stats.yaml
+++ b/docs/examples/petkit_fountain_stats.yaml
@@ -1,0 +1,76 @@
+# PetKit fountain local drink stats package.
+#
+# Drop this file into your Home Assistant config under `packages/`, then make
+# sure packages are loaded:
+#
+#   homeassistant:
+#     packages: !include_dir_named packages
+#
+# Pair with the `fountain_drink_counter` blueprint (drinks counter) and
+# optionally the three `fountain_*_drinks_alert` blueprints (anomaly alerts).
+# When you create an automation from the counter blueprint, point it at
+# `counter.petkit_fountain_drinks_total` below and turn OFF the "Reset counter
+# daily" option. The daily/weekly/monthly cycles are handled by the utility
+# meters here, not by counter resets.
+#
+# Edit the binary_sensor entity_id below to match your fountain.
+
+counter:
+  petkit_fountain_drinks_total:
+    name: Petkit fountain drinks total
+    icon: mdi:cup-water
+    initial: 0
+    step: 1
+    restore: true
+
+utility_meter:
+  petkit_fountain_drinks_today:
+    source: counter.petkit_fountain_drinks_total
+    name: Petkit fountain drinks today
+    cycle: daily
+  petkit_fountain_drinks_weekly:
+    source: counter.petkit_fountain_drinks_total
+    name: Petkit fountain drinks this week
+    cycle: weekly
+  petkit_fountain_drinks_monthly:
+    source: counter.petkit_fountain_drinks_total
+    name: Petkit fountain drinks this month
+    cycle: monthly
+
+sensor:
+  - platform: history_stats
+    name: Petkit fountain drink time today
+    entity_id: binary_sensor.REPLACE_ME_pet_drinking
+    state: "on"
+    type: time
+    start: "{{ today_at('00:00') }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: Petkit fountain drink time this week
+    entity_id: binary_sensor.REPLACE_ME_pet_drinking
+    state: "on"
+    type: time
+    start: "{{ now().replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=now().weekday()) }}"
+    end: "{{ now() }}"
+  - platform: statistics
+    name: Petkit fountain drinks median
+    unique_id: petkit_fountain_drinks_median
+    entity_id: sensor.petkit_fountain_drinks_final_today
+    state_characteristic: median
+    sampling_size: 14
+    max_age:
+      days: 8
+
+# Daily snapshot of today's final drink count, sampled at 23:55. The
+# `sensor.petkit_fountain_drinks_today` utility_meter resets to 0 at midnight,
+# so we capture the day's value just before the rollover. The statistics
+# sensor above takes its 7-day median from these snapshots.
+template:
+  - trigger:
+      - platform: time
+        at: "23:55:00"
+    sensor:
+      - name: Petkit fountain drinks final today
+        unique_id: petkit_fountain_drinks_final_today
+        state: "{{ states('sensor.petkit_fountain_drinks_today') | int(0) }}"
+        state_class: measurement


### PR DESCRIPTION
> Part of an ongoing effort to make the PetKit app and cloud optional for daily fountain monitoring. This PR covers drink tracking and anomaly alerts. It pairs with #203 (local BLE reads) and #202 (BLE writes for mode/LED/DND).

## 📝 Proposed Change / Description

Adds four importable HA blueprints and a package YAML for tracking fountain drinks locally and alerting on anomalies.

**Blueprints**

| Blueprint                    | What it does                                                                          |
| ---------------------------- | ------------------------------------------------------------------------------------- |
| `fountain_drink_counter`     | Increments a counter on each `off`/`on` transition of the `Pet drinking` binary sensor, with an optional daily reset. |
| `fountain_no_drinks_alert`   | Fires when the sensor has stayed `off` for X hours (default 12).                      |
| `fountain_low_drinks_alert`  | Fires once a day at 20:00 if today's count is below 30% of the 7-day median.          |
| `fountain_high_drinks_alert` | Fires once a day at 20:00 if today's count is above 200% of the 7-day median.         |

**Package**

`docs/examples/petkit_fountain_stats.yaml` wires up the supporting infrastructure: a non-resetting lifetime counter, daily/weekly/monthly `utility_meter` cycles, two `history_stats` sensors for drink time, a trigger-template snapshot sensor that captures today's count at 23:55, and a `statistics` sensor that takes the 7-day median over those snapshots. The alert blueprints default to reading from this package's entities.

`docs/automations.md` covers a quick-start (counter only), full setup (counter + meters + alerts), troubleshooting, the calibration period for statistical alerts, and multi-fountain notes.

No Python changes.

**Fixes:** n/a

---

## 🔖 Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔧 Refactor / code cleanup (no functional change)
- [x] 📚 Documentation update
- [ ] 🔒 Security fix
- [ ] ⬆️ Dependency update

---

## 🐾 Affected devices

The blueprints target the `Pet drinking` binary sensor (occupancy device class) registered for the Fountain platform. Works regardless of whether `detect_status` comes from cloud-relay or local BLE.

- [ ] 🌐 All devices

**Specific type:**

- [ ] Litter boxes :
- [ ] Feeders :
- [x] Fountains : CTW3 / Eversweet Max 2 verified. Structurally applies to any fountain that exposes the `Pet drinking` sensor.
- [ ] Purifiers :

---

## 🧪 How has this been tested?

- [x] Tested locally with a real PetKit device
- [x] Tested with Home Assistant version: 2026.4.4

**Device(s) tested on:**

PetKit Eversweet Max 2 Cordless (CTW3UV).

**Other devices you own when the test was done:**

None.

**Test procedure:**

1. Imported all four blueprints into HA.
2. Dropped `petkit_fountain_stats.yaml` into `<config>/packages/`, replaced the binary_sensor placeholder.
3. Restarted HA. Verified all entities appeared (counter, daily/weekly/monthly meters, drink-time, daily snapshot, 7-day median).
4. Created automations from each blueprint. All loaded with `state: on`.
5. Counter test: triggered drink events (off/on/off transitions). Counter incremented, utility meters baselined and tracked, `history_stats` reflected uptime. Values survived a Home Assistant restart.
6. Alert test: manually triggered `automation.fountain_no_drinks_alert` via `automation.trigger`. Action ran without errors. Statistical alerts can't be end-to-end tested without 7 days of history; their structure (templates, conditions, blueprint inputs) is validated via blueprint loading and `pre-commit run -a`.

---

## ✅ Checklist

- [x] Code follows project style : `pre-commit run -a` hooks and all checks pass
- [x] No new linting/type errors introduced
- [x] Documentation updated (if needed)
- [x] Branch is up-to-date with `main`

---

## 📸 Screenshots / Logs (optional)

Entity snapshot after restart with all blueprints loaded:

```
counter.petkit_fountain_drinks_total            = 2
sensor.petkit_fountain_drinks_today             = 1
sensor.petkit_fountain_drinks_this_week         = 1
sensor.petkit_fountain_drinks_this_month        = 1
sensor.petkit_fountain_drink_time_today         = 0.0
sensor.petkit_fountain_drink_time_this_week    = 12.41
sensor.petkit_fountain_drinks_final_today       = unknown   (fires at 23:55)
sensor.petkit_fountain_drinks_median            = unknown   (needs at least one snapshot)
automation.fountain_drink_counter               = on
automation.fountain_no_drinks_alert             = on
automation.fountain_low_drinks_alert            = on
automation.fountain_high_drinks_alert           = on
```

---

## ℹ️ Additional context

- Independent of #203 (local BLE reads) and #202 (BLE writes). Only needs `binary_sensor.X_pet_drinking`, which already exists on `main`.
- Default thresholds (12h, <30%, >200% of median) are guesses tuned for a single-cat household. All exposed as blueprint inputs.
- Low/high alerts have a 7-day calibration period. "No drinks" alert works from day one.
- `.pre-commit-config.yaml` excludes `^blueprints/` from `check-yaml` (HA's `!input` tag isn't a standard YAML constructor).
- Could later move to a HACS-installable companion repo (`category: blueprint`) for auto-updates.

---

## ⚠️ Breaking Changes

- [x] No breaking changes.
- [ ] **Warning:** This PR introduces breaking changes.

---

## Thanks for the helping paw! 🐾