### PR TITLE
Improve config flow UX: collapsed advanced section, server-list region picker, clearer username hint

### DIFF
--- a/custom_components/petkit/__init__.py
+++ b/custom_components/petkit/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import ServiceCall
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.loader import async_get_loaded_integration
@@ -237,6 +238,20 @@ async def async_setup_entry(
     )
 
     await coordinator.async_config_entry_first_refresh()
+
+    # Login succeeded but PetKit returned no devices. Most common cause is
+    # that the user logged in with a secondary account that has not yet
+    # accepted the Family Management invitation in the PetKit mobile app.
+    # Without this check, the integration silently sets up with zero
+    # entities and the user has no idea why.
+    if not entry.runtime_data.client.petkit_entities:
+        raise ConfigEntryNotReady(
+            "PetKit login succeeded, but no devices are shared with this "
+            "account. Open the PetKit mobile app, accept the Family "
+            "Management invitation for this account, and then reload this "
+            "integration."
+        )
+
     await coordinator_media.async_config_entry_first_refresh()
     await coordinator_bluetooth.async_config_entry_first_refresh()
 

--- a/custom_components/petkit/config_flow.py
+++ b/custom_components/petkit/config_flow.py
@@ -122,9 +122,7 @@ async def _fetch_petkit_servers(
         servers.append(
             {
                 "gateway": "https://api.petkit.cn/6/",
-                "label": PETKIT_SERVER_LABELS.get(
-                    "https://api.petkit.cn/6/", "China"
-                ),
+                "label": PETKIT_SERVER_LABELS.get("https://api.petkit.cn/6/", "China"),
                 "country": "CN",
                 "countries": ["CN"],
             }
@@ -306,9 +304,7 @@ class PetkitFlowHandler(ConfigFlow, domain=DOMAIN):
             # Accept either dropdown shape: server-mode delivers an ISO code
             # already, country-mode delivers a country name we look up.
             user_region = (
-                COUNTRY_TO_CODE_DICT.get(raw_region)
-                or raw_region
-                or country_from_ha
+                COUNTRY_TO_CODE_DICT.get(raw_region) or raw_region or country_from_ha
             )
             user_timezone = advanced.get(CONF_TIME_ZONE) or tz_from_ha
 
@@ -401,9 +397,9 @@ class PetkitFlowHandler(ConfigFlow, domain=DOMAIN):
         else:
             # API unreachable: keep the legacy 200-country dropdown so users
             # can still complete setup manually.
-            region_default = prev_advanced.get(
-                CONF_REGION
-            ) or CODE_TO_COUNTRY_DICT.get(country_from_ha, country_from_ha)
+            region_default = prev_advanced.get(CONF_REGION) or CODE_TO_COUNTRY_DICT.get(
+                country_from_ha, country_from_ha
+            )
             region_selector = selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=sorted(CODE_TO_COUNTRY_DICT.values())

--- a/custom_components/petkit/config_flow.py
+++ b/custom_components/petkit/config_flow.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
+import aiohttp
 from pypetkitapi import (
     PetkitAuthenticationUnregisteredEmailError,
     PetKitClient,
@@ -35,6 +37,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import BooleanSelector, BooleanSelectorConfig
 
 from .const import (
+    ADVANCED_SECTION,
     ALL_TIMEZONES_LST,
     BT_SECTION,
     CODE_TO_COUNTRY_DICT,
@@ -62,7 +65,73 @@ from .const import (
     MEDIA_SECTION,
     NOTIFICATION_CATEGORIES,
     NOTIFICATION_SECTION,
+    PETKIT_REGION_SERVERS_URL,
+    PETKIT_SERVER_LABELS,
 )
+
+
+async def _fetch_petkit_servers(
+    session: aiohttp.ClientSession,
+) -> list[dict[str, Any]] | None:
+    """Fetch the PetKit gateway list grouped by server.
+
+    Returns a list of dicts with `label` (friendly server name) and
+    `country` (ISO code we feed back to pypetkitapi). Returns `None` when
+    the API is unreachable so the caller can fall back to the full country
+    dropdown.
+    """
+    try:
+        async with asyncio.timeout(5):
+            async with session.get(PETKIT_REGION_SERVERS_URL) as resp:
+                resp.raise_for_status()
+                payload = await resp.json()
+    except (TimeoutError, aiohttp.ClientError, ValueError) as exc:
+        LOGGER.debug("Failed to fetch PetKit region servers: %s", exc)
+        return None
+
+    countries_by_gateway: dict[str, list[str]] = {}
+    for entry in payload.get("result", {}).get("list", []):
+        gateway = entry.get("gateway")
+        country = entry.get("id")
+        if not gateway or not country:
+            continue
+        countries_by_gateway.setdefault(gateway, []).append(country)
+
+    if not countries_by_gateway:
+        return None
+
+    servers: list[dict[str, Any]] = []
+    for gateway, countries in countries_by_gateway.items():
+        label = PETKIT_SERVER_LABELS.get(gateway, gateway)
+        servers.append(
+            {
+                "gateway": gateway,
+                "label": label,
+                # First country alphabetically so the value is stable across
+                # API responses (PetKit's list order is not guaranteed).
+                "country": sorted(countries)[0],
+                "countries": countries,
+            }
+        )
+
+    # PetKit's regionservers endpoint omits the China-only gateway because
+    # the China cloud is reached via a separate path inside pypetkitapi
+    # (`region.lower() == "cn"`). Surface it manually so Chinese users can
+    # actually pick it.
+    if not any(s["country"] == "CN" for s in servers):
+        servers.append(
+            {
+                "gateway": "https://api.petkit.cn/6/",
+                "label": PETKIT_SERVER_LABELS.get(
+                    "https://api.petkit.cn/6/", "China"
+                ),
+                "country": "CN",
+                "countries": ["CN"],
+            }
+        )
+
+    servers.sort(key=lambda s: s["label"])
+    return servers
 
 
 class PetkitOptionsFlowHandler(OptionsFlow):
@@ -218,11 +287,39 @@ class PetkitFlowHandler(ConfigFlow, domain=DOMAIN):
             f"Country code from HA : {self.hass.config.country} Default timezone: {tz_from_ha}"
         )
 
+        # PetKit's Chinese cloud uses phone/ID logins; the international cloud
+        # uses email. Tailor the hint based on the user's HA country so the
+        # 99% case isn't shown a confusing "or id if you are a Chinese user".
+        if country_from_ha == "CN":
+            username_hint = "Enter your PetKit account phone number or PetKit ID."
+        else:
+            username_hint = "Enter your PetKit account email."
+
+        # Fetch the live PetKit gateway list so we can render a short server
+        # dropdown (~5 entries) instead of a 200+ country list. If the call
+        # fails we silently fall back to the country list below.
+        servers = await _fetch_petkit_servers(async_get_clientsession(self.hass))
+
         if user_input is not None:
+            advanced = user_input.get(ADVANCED_SECTION, {})
+            raw_region = advanced.get(CONF_REGION)
+            # Accept either dropdown shape: server-mode delivers an ISO code
+            # already, country-mode delivers a country name we look up.
             user_region = (
-                COUNTRY_TO_CODE_DICT.get(user_input.get(CONF_REGION, None))
+                COUNTRY_TO_CODE_DICT.get(raw_region)
+                or raw_region
                 or country_from_ha
             )
+            user_timezone = advanced.get(CONF_TIME_ZONE) or tz_from_ha
+
+            # Flatten section data for storage so __init__.py keeps reading
+            # CONF_REGION/CONF_TIME_ZONE at the top level of entry.data.
+            entry_data = {
+                CONF_USERNAME: user_input[CONF_USERNAME],
+                CONF_PASSWORD: user_input[CONF_PASSWORD],
+                CONF_REGION: user_region,
+                CONF_TIME_ZONE: user_timezone,
+            }
 
             # Check if the account already exists
             existing_entries = self._async_current_entries()
@@ -236,7 +333,7 @@ class PetkitFlowHandler(ConfigFlow, domain=DOMAIN):
                         username=user_input[CONF_USERNAME],
                         password=user_input[CONF_PASSWORD],
                         region=user_region,
-                        timezone=user_input.get(CONF_TIME_ZONE, tz_from_ha),
+                        timezone=user_timezone,
                     )
                 except (
                     PetkitTimeoutError,
@@ -253,7 +350,7 @@ class PetkitFlowHandler(ConfigFlow, domain=DOMAIN):
                 else:
                     return self.async_create_entry(
                         title=user_input[CONF_USERNAME],
-                        data=user_input,
+                        data=entry_data,
                         options={
                             MEDIA_SECTION: {
                                 CONF_MEDIA_PATH: DEFAULT_MEDIA_PATH,
@@ -275,49 +372,86 @@ class PetkitFlowHandler(ConfigFlow, domain=DOMAIN):
                         },
                     )
 
-        data_schema = {
-            vol.Required(
-                CONF_USERNAME,
-                default=(user_input or {}).get(CONF_USERNAME, vol.UNDEFINED),
-            ): selector.TextSelector(
-                selector.TextSelectorConfig(
-                    type=selector.TextSelectorType.TEXT,
-                ),
-            ),
-            vol.Required(CONF_PASSWORD): selector.TextSelector(
-                selector.TextSelectorConfig(
-                    type=selector.TextSelectorType.PASSWORD,
-                ),
-            ),
-        }
+        prev_advanced = (user_input or {}).get(ADVANCED_SECTION, {})
+        tz_default = prev_advanced.get(CONF_TIME_ZONE) or tz_from_ha
 
-        if _errors:
-            data_schema.update(
-                {
-                    vol.Required(
-                        CONF_REGION,
-                        default=CODE_TO_COUNTRY_DICT.get(
-                            country_from_ha, country_from_ha
-                        ),
-                    ): selector.SelectSelector(
-                        selector.SelectSelectorConfig(
-                            options=sorted(CODE_TO_COUNTRY_DICT.values())
-                        ),
-                    ),
-                    vol.Required(
-                        CONF_TIME_ZONE, default=tz_from_ha
-                    ): selector.SelectSelector(
-                        selector.SelectSelectorConfig(options=ALL_TIMEZONES_LST),
-                    ),
-                }
+        if servers:
+            region_options = [
+                selector.SelectOptionDict(value=s["country"], label=s["label"])
+                for s in servers
+            ]
+            valid_region_values = {s["country"] for s in servers}
+            # Find the server whose country bucket contains the HA country and
+            # default to that server's representative code. If HA's country is
+            # not in any bucket, fall back to the first listed server.
+            auto_server = next(
+                (s for s in servers if country_from_ha in s["countries"]),
+                servers[0],
             )
+            auto_default = auto_server["country"]
+            prev_region = prev_advanced.get(CONF_REGION)
+            # Drop a previously selected value if it is from the old country
+            # dropdown so voluptuous doesn't render an empty selector.
+            region_default = (
+                prev_region if prev_region in valid_region_values else auto_default
+            )
+            region_selector = selector.SelectSelector(
+                selector.SelectSelectorConfig(options=region_options)
+            )
+        else:
+            # API unreachable: keep the legacy 200-country dropdown so users
+            # can still complete setup manually.
+            region_default = prev_advanced.get(
+                CONF_REGION
+            ) or CODE_TO_COUNTRY_DICT.get(country_from_ha, country_from_ha)
+            region_selector = selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=sorted(CODE_TO_COUNTRY_DICT.values())
+                ),
+            )
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_USERNAME,
+                    default=(user_input or {}).get(CONF_USERNAME, vol.UNDEFINED),
+                ): selector.TextSelector(
+                    selector.TextSelectorConfig(
+                        type=selector.TextSelectorType.TEXT,
+                    ),
+                ),
+                vol.Required(CONF_PASSWORD): selector.TextSelector(
+                    selector.TextSelectorConfig(
+                        type=selector.TextSelectorType.PASSWORD,
+                    ),
+                ),
+                vol.Required(ADVANCED_SECTION): section(
+                    vol.Schema(
+                        {
+                            vol.Required(
+                                CONF_REGION, default=region_default
+                            ): region_selector,
+                            vol.Required(
+                                CONF_TIME_ZONE, default=tz_default
+                            ): selector.SelectSelector(
+                                selector.SelectSelectorConfig(
+                                    options=ALL_TIMEZONES_LST
+                                ),
+                            ),
+                        }
+                    ),
+                    {"collapsed": True},
+                ),
+            }
+        )
 
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(data_schema),
+            data_schema=data_schema,
             errors=_errors,
             description_placeholders={
-                "wiki_url": "https://github.com/Jezza34000/homeassistant_petkit/wiki/Configuration"
+                "username_hint": username_hint,
+                "wiki_url": "https://github.com/Jezza34000/homeassistant_petkit/wiki/Configuration",
             },
         )
 

--- a/custom_components/petkit/config_flow.py
+++ b/custom_components/petkit/config_flow.py
@@ -321,9 +321,7 @@ class PetkitFlowHandler(ConfigFlow, domain=DOMAIN):
 
         if servers:
             region_options = [
-                selector.SelectOptionDict(
-                    value=s.representative_country, label=s.label
-                )
+                selector.SelectOptionDict(value=s.representative_country, label=s.label)
                 for s in servers
             ]
             valid_region_values = {s.representative_country for s in servers}

--- a/custom_components/petkit/config_flow.py
+++ b/custom_components/petkit/config_flow.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
-import aiohttp
 from pypetkitapi import (
     PetkitAuthenticationUnregisteredEmailError,
     PetKitClient,
@@ -14,6 +12,7 @@ from pypetkitapi import (
     PetkitSessionExpiredError,
     PetkitTimeoutError,
     PypetkitError,
+    RegionServerGroup,
 )
 import voluptuous as vol
 
@@ -65,71 +64,7 @@ from .const import (
     MEDIA_SECTION,
     NOTIFICATION_CATEGORIES,
     NOTIFICATION_SECTION,
-    PETKIT_REGION_SERVERS_URL,
-    PETKIT_SERVER_LABELS,
 )
-
-
-async def _fetch_petkit_servers(
-    session: aiohttp.ClientSession,
-) -> list[dict[str, Any]] | None:
-    """Fetch the PetKit gateway list grouped by server.
-
-    Returns a list of dicts with `label` (friendly server name) and
-    `country` (ISO code we feed back to pypetkitapi). Returns `None` when
-    the API is unreachable so the caller can fall back to the full country
-    dropdown.
-    """
-    try:
-        async with asyncio.timeout(5):
-            async with session.get(PETKIT_REGION_SERVERS_URL) as resp:
-                resp.raise_for_status()
-                payload = await resp.json()
-    except (TimeoutError, aiohttp.ClientError, ValueError) as exc:
-        LOGGER.debug("Failed to fetch PetKit region servers: %s", exc)
-        return None
-
-    countries_by_gateway: dict[str, list[str]] = {}
-    for entry in payload.get("result", {}).get("list", []):
-        gateway = entry.get("gateway")
-        country = entry.get("id")
-        if not gateway or not country:
-            continue
-        countries_by_gateway.setdefault(gateway, []).append(country)
-
-    if not countries_by_gateway:
-        return None
-
-    servers: list[dict[str, Any]] = []
-    for gateway, countries in countries_by_gateway.items():
-        label = PETKIT_SERVER_LABELS.get(gateway, gateway)
-        servers.append(
-            {
-                "gateway": gateway,
-                "label": label,
-                # First country alphabetically so the value is stable across
-                # API responses (PetKit's list order is not guaranteed).
-                "country": sorted(countries)[0],
-                "countries": countries,
-            }
-        )
-
-    # PetKit's regionservers endpoint omits the China-only gateway because
-    # the China cloud is reached via a separate path inside pypetkitapi
-    # (`region.lower() == "cn"`). Surface it manually so Chinese users can
-    # actually pick it.
-    if not any(s["country"] == "CN" for s in servers):
-        servers.append(
-            {
-                "gateway": "https://api.petkit.cn/6/",
-                "label": PETKIT_SERVER_LABELS.get("https://api.petkit.cn/6/", "China"),
-                "country": "CN",
-                "countries": ["CN"],
-            }
-        )
-
-    servers.sort(key=lambda s: s["label"])
-    return servers
 
 
 class PetkitOptionsFlowHandler(OptionsFlow):
@@ -296,7 +231,14 @@ class PetkitFlowHandler(ConfigFlow, domain=DOMAIN):
         # Fetch the live PetKit gateway list so we can render a short server
         # dropdown (~5 entries) instead of a 200+ country list. If the call
         # fails we silently fall back to the country list below.
-        servers = await _fetch_petkit_servers(async_get_clientsession(self.hass))
+        servers: list[RegionServerGroup] | None
+        try:
+            servers = await PetKitClient.fetch_region_servers(
+                async_get_clientsession(self.hass)
+            )
+        except PypetkitError as exc:
+            LOGGER.debug("Failed to fetch PetKit region servers: %s", exc)
+            servers = None
 
         if user_input is not None:
             advanced = user_input.get(ADVANCED_SECTION, {})
@@ -373,18 +315,20 @@ class PetkitFlowHandler(ConfigFlow, domain=DOMAIN):
 
         if servers:
             region_options = [
-                selector.SelectOptionDict(value=s["country"], label=s["label"])
+                selector.SelectOptionDict(
+                    value=s.representative_country, label=s.label
+                )
                 for s in servers
             ]
-            valid_region_values = {s["country"] for s in servers}
+            valid_region_values = {s.representative_country for s in servers}
             # Find the server whose country bucket contains the HA country and
             # default to that server's representative code. If HA's country is
             # not in any bucket, fall back to the first listed server.
             auto_server = next(
-                (s for s in servers if country_from_ha in s["countries"]),
+                (s for s in servers if country_from_ha in s.countries),
                 servers[0],
             )
-            auto_default = auto_server["country"]
+            auto_default = auto_server.representative_country
             prev_region = prev_advanced.get(CONF_REGION)
             # Drop a previously selected value if it is from the old country
             # dropdown so voluptuous doesn't render an empty selector.

--- a/custom_components/petkit/const.py
+++ b/custom_components/petkit/const.py
@@ -16,6 +16,26 @@ AGORA_APP_ID = "244c49951296440cbc1e3b937bf5e410"
 # Configuration
 CONF_SCAN_INTERVAL_MEDIA = "scan_interval_media"
 
+ADVANCED_SECTION = "advanced_options"
+
+# PetKit publishes the country to gateway mapping at this URL. We use it
+# during config flow to show users a short list of regional servers (~5)
+# instead of a 200+ country dropdown. If the call fails we fall back to the
+# country list below.
+PETKIT_REGION_SERVERS_URL = "https://passport.petkt.com/v1/regionservers"
+
+# Friendly English labels for the real PetKit gateways. Keys must match the
+# `gateway` field returned by /v1/regionservers verbatim. The Chinese
+# gateway is included even though the regionservers endpoint omits it,
+# since pypetkitapi reaches that cloud through a separate code path.
+PETKIT_SERVER_LABELS = {
+    "https://api.eu-pet.com/latest/": "Europe",
+    "https://api.petkt.com/latest/": "International (Americas, global)",
+    "https://api.petktasia.com/latest/": "Asia",
+    "https://api-ru.petkit.cn/latest/": "Russia",
+    "https://api.petkit.cn/6/": "China",
+}
+
 BT_SECTION = "bluetooth_options"
 CONF_BLE_RELAY_ENABLED = "ble_relay_enabled"
 CONF_SCAN_INTERVAL_BLUETOOTH = "scan_interval_bluetooth"

--- a/custom_components/petkit/const.py
+++ b/custom_components/petkit/const.py
@@ -18,24 +18,6 @@ CONF_SCAN_INTERVAL_MEDIA = "scan_interval_media"
 
 ADVANCED_SECTION = "advanced_options"
 
-# PetKit publishes the country to gateway mapping at this URL. We use it
-# during config flow to show users a short list of regional servers (~5)
-# instead of a 200+ country dropdown. If the call fails we fall back to the
-# country list below.
-PETKIT_REGION_SERVERS_URL = "https://passport.petkt.com/v1/regionservers"
-
-# Friendly English labels for the real PetKit gateways. Keys must match the
-# `gateway` field returned by /v1/regionservers verbatim. The Chinese
-# gateway is included even though the regionservers endpoint omits it,
-# since pypetkitapi reaches that cloud through a separate code path.
-PETKIT_SERVER_LABELS = {
-    "https://api.eu-pet.com/latest/": "Europe",
-    "https://api.petkt.com/latest/": "International (Americas, global)",
-    "https://api.petktasia.com/latest/": "Asia",
-    "https://api-ru.petkit.cn/latest/": "Russia",
-    "https://api.petkit.cn/6/": "China",
-}
-
 BT_SECTION = "bluetooth_options"
 CONF_BLE_RELAY_ENABLED = "ble_relay_enabled"
 CONF_SCAN_INTERVAL_BLUETOOTH = "scan_interval_bluetooth"

--- a/custom_components/petkit/manifest.json
+++ b/custom_components/petkit/manifest.json
@@ -10,7 +10,7 @@
   "issue_tracker": "https://github.com/Jezza34000/homeassistant_petkit/issues",
   "loggers": ["petkit"],
   "requirements": [
-    "pypetkitapi==1.26.1",
+    "pypetkitapi==1.27.0",
     "aiofiles==24.1.0",
     "paho-mqtt==2.1.0",
     "websockets==15.0.1",

--- a/custom_components/petkit/translations/en.json
+++ b/custom_components/petkit/translations/en.json
@@ -9,16 +9,26 @@
       "user": {
         "data": {
           "password": "Password",
-          "region": "Region",
-          "time_zone": "Timezone",
-          "username": "Username/Id"
+          "username": "Username"
         },
         "data_description": {
-          "region": "This field is automatically completed based on your Home Assistant configuration. If you have a different region, please select it from the list.",
-          "time_zone": "This field is automatically completed based on your Home Assistant configuration. If you have a different timezone, please select it from the list.",
-          "username": "Enter your PetKit account email, or id if you are a Chinese user"
+          "username": "{username_hint}"
         },
-        "description": "Enter the PetKit account that Home Assistant will use to talk to PetKit's cloud.\n\n**Important:** this must be a *separate* PetKit account from the one you sign in to the mobile app with. PetKit only allows one active session per account, so signing in here with your main account will log you out of the app (and vice versa).\n\n**Setup:**\n1. Create a second PetKit account (different email).\n2. In the PetKit mobile app, signed in as your main account, open **Family Management** and create a family.\n3. Invite the second account as a family member and accept the invite.\n4. Enter the second account's credentials below.\n\nFull guide: [Configuration wiki]({wiki_url})."
+        "description": "Enter the PetKit account that Home Assistant will use to talk to PetKit's cloud.\n\n**Important:** this must be a *separate* PetKit account from the one you sign in to the mobile app with. PetKit only allows one active session per account, so signing in here with your main account will log you out of the app (and vice versa).\n\n**Setup:**\n1. Create a second PetKit account (different email).\n2. In the PetKit mobile app, signed in as your main account, open **Family Management** and create a family.\n3. Invite the second account as a family member and accept the invite.\n4. Enter the second account's credentials below.\n\nFull guide: [Configuration wiki]({wiki_url}).",
+        "sections": {
+          "advanced_options": {
+            "data": {
+              "region": "Region",
+              "time_zone": "Timezone"
+            },
+            "data_description": {
+              "region": "Auto-detected from Home Assistant. Override only if your PetKit account is registered with a different regional server.",
+              "time_zone": "Auto-detected from Home Assistant. Override if needed."
+            },
+            "description": "Region and timezone are auto-detected from Home Assistant. Expand only if you need to override them.",
+            "name": "Advanced"
+          }
+        }
       }
     }
   },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 aiofiles==24.1.0
-pypetkitapi==1.26.1
+pypetkitapi==1.27.0


### PR DESCRIPTION
## 📝 Proposed Change / Description

Three small UX cleanups to the initial account-login form, plus one related setup-failure fix. The server-list fetch lives in `pypetkitapi` after [py-petkit-api#73](https://github.com/Jezza34000/py-petkit-api/pull/73), so this PR consumes the new public API instead of duplicating it.

- Move region/timezone into a collapsed **Advanced** section (defaults from HA config). Removes the chicken-and-egg where the user had to fail login before getting access to the region picker.
- Replace the 200+ country dropdown with a 5-entry list of PetKit's actual gateways (Europe, International, Asia, Russia, China). Server list comes from `PetKitClient.fetch_region_servers()` (added in pypetkitapi 1.27.0). Falls back to the country dropdown if the call fails. China is included by the library since `/v1/regionservers` omits it.
- Rename `Username/Id` to `Username` and switch the helper text on `hass.config.country` (CN gets phone/PetKit-ID hint, others get email hint).
- In `__init__.py`: when login succeeds but no devices are returned (typical for a secondary account that has not yet accepted the Family Management invite), raise `ConfigEntryNotReady` with a clear message instead of silently configuring zero entities.

Storage format unchanged: section data is flattened back to top-level `CONF_REGION`/`CONF_TIME_ZONE` in `entry.data`. Only `translations/en.json` updated; other languages will fall back to English on the new keys until Weblate syncs.

**Depends on:** [Jezza34000/py-petkit-api#73](https://github.com/Jezza34000/py-petkit-api/pull/73) and a 1.27.0 release.

**Fixes:** #---

---

## 🔖 Type of change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🔧 Refactor / code cleanup (no functional change)

---

## 🐾 Affected devices

- [x] 🌐 All devices (config flow is shared)

---

## 🧪 How has this been tested?

- [x] Tested locally with a real PetKit device
- [x] Tested with Home Assistant version: 2026.4.4

**Device(s) tested on:** Eversweet Max 2 (CTW3)

Verified: initial form renders with collapsed Advanced; expanding shows 5 server options with Europe auto-selected for HA-NO; failed login preserves user input; existing entries continue to load after upgrade. Family Management `ConfigEntryNotReady` path was not exercised live (no test account without Family Management).

---

## ✅ Checklist

- [x] Code follows project style: `pre-commit run -a` hooks and all checks pass
- [x] No new linting/type errors introduced
- [ ] Documentation updated (if needed)
- [x] Branch is up-to-date with `main`

---

## 📸 Screenshots

Initial form (collapsed Advanced):

![after-d1-initial](https://github.com/user-attachments/assets/2afe0bed-930b-49af-9c49-cb9efd0faf90)

Advanced expanded (5 server options, Europe pre-selected for HA-NO):

![after-d1-advanced](https://github.com/user-attachments/assets/78eb8a31-dd3a-4cec-859c-8fef92349820)

Failed login preserves the username field:

![after-d1-failed-login](https://github.com/user-attachments/assets/bf0df5ae-fdf3-432b-980a-6e61216c8c4d)

---

## ⚠️ Breaking Changes

- [x] No breaking changes.