### PR TITLE
Collaboration PR for Eversweet Ultra support

### DIFF
--- a/custom_components/petkit/__init__.py
+++ b/custom_components/petkit/__init__.py
@@ -47,6 +47,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL_BLUETOOTH,
     DEFAULT_SCAN_INTERVAL_MEDIA,
     DOMAIN,
+    FOUNTAIN_MEDIA_EVENTS,
     LOGGER,
     MEDIA_SECTION,
     NOTIFICATION_SECTION,
@@ -396,6 +397,17 @@ async def async_migrate_entry(hass: HomeAssistant, entry: PetkitConfigEntry) -> 
             ]
         new_options[MEDIA_SECTION] = media_section
         hass.config_entries.async_update_entry(entry, options=new_options, version=9)
+
+    if entry.version < 10:
+        new_options = dict(entry.options)
+        media_section = dict(new_options.get(MEDIA_SECTION, {}))
+        events = list(media_section.get(CONF_MEDIA_EV_TYPE, DEFAULT_EVENTS))
+        for event in FOUNTAIN_MEDIA_EVENTS:
+            if event not in events:
+                events.append(event)
+        media_section[CONF_MEDIA_EV_TYPE] = events
+        new_options[MEDIA_SECTION] = media_section
+        hass.config_entries.async_update_entry(entry, options=new_options, version=10)
 
     return True
 

--- a/custom_components/petkit/__init__.py
+++ b/custom_components/petkit/__init__.py
@@ -385,6 +385,18 @@ async def async_migrate_entry(hass: HomeAssistant, entry: PetkitConfigEntry) -> 
         new_options[NOTIFICATION_SECTION] = section
         hass.config_entries.async_update_entry(entry, options=new_options, version=8)
 
+    if entry.version < 9:
+        new_options = dict(entry.options)
+        media_section = dict(new_options.get(MEDIA_SECTION, {}))
+        events = media_section.get(CONF_MEDIA_EV_TYPE)
+        if events:
+            media_section[CONF_MEDIA_EV_TYPE] = [
+                "Pet_detect" if event == "Pet_detected" else event
+                for event in events
+            ]
+        new_options[MEDIA_SECTION] = media_section
+        hass.config_entries.async_update_entry(entry, options=new_options, version=9)
+
     return True
 
 

--- a/custom_components/petkit/__init__.py
+++ b/custom_components/petkit/__init__.py
@@ -392,8 +392,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: PetkitConfigEntry) -> 
         events = media_section.get(CONF_MEDIA_EV_TYPE)
         if events:
             media_section[CONF_MEDIA_EV_TYPE] = [
-                "Pet_detect" if event == "Pet_detected" else event
-                for event in events
+                "Pet_detect" if event == "Pet_detected" else event for event in events
             ]
         new_options[MEDIA_SECTION] = media_section
         hass.config_entries.async_update_entry(entry, options=new_options, version=9)

--- a/custom_components/petkit/binary_sensor.py
+++ b/custom_components/petkit/binary_sensor.py
@@ -331,13 +331,6 @@ BINARY_SENSOR_MAPPING: dict[type[PetkitDevices], list[PetKitBinarySensorDesc]] =
             only_for_types=[W7H],
         ),
         PetKitBinarySensorDesc(
-            key="Camera status",
-            translation_key="camera_status",
-            device_class=BinarySensorDeviceClass.RUNNING,
-            value=lambda device: device.state.camera_status,
-            only_for_types=[W7H],
-        ),
-        PetKitBinarySensorDesc(
             key="Heater installed",
             translation_key="heater_installed",
             entity_category=EntityCategory.DIAGNOSTIC,

--- a/custom_components/petkit/binary_sensor.py
+++ b/custom_components/petkit/binary_sensor.py
@@ -266,6 +266,7 @@ BINARY_SENSOR_MAPPING: dict[type[PetkitDevices], list[PetKitBinarySensorDesc]] =
             translation_key="pump_running",
             device_class=BinarySensorDeviceClass.RUNNING,
             value=get_pump_running_status,
+            ignore_types=[W7H],
         ),
         PetKitBinarySensorDesc(
             key="Pump running",
@@ -285,21 +286,21 @@ BINARY_SENSOR_MAPPING: dict[type[PetkitDevices], list[PetKitBinarySensorDesc]] =
             key="Clean water tank low",
             translation_key="clean_water_tank_low",
             device_class=BinarySensorDeviceClass.PROBLEM,
-            value=lambda device: device.state.stg_full_state == 0,
+            value=lambda device: device.state.cwt_state == 3,
             only_for_types=[W7H],
         ),
         PetKitBinarySensorDesc(
             key="Clean water tank empty",
             translation_key="clean_water_tank_empty",
             device_class=BinarySensorDeviceClass.PROBLEM,
-            value=lambda device: device.state.cwt_state != 0,
+            value=lambda device: device.state.cwt_state == 2,
             only_for_types=[W7H],
         ),
         PetKitBinarySensorDesc(
             key="Waste tank full",
             translation_key="waste_tank_full",
             device_class=BinarySensorDeviceClass.PROBLEM,
-            value=lambda device: device.state.wt_state == 0,
+            value=lambda device: device.state.wt_state == 2,
             only_for_types=[W7H],
         ),
         PetKitBinarySensorDesc(
@@ -324,10 +325,10 @@ BINARY_SENSOR_MAPPING: dict[type[PetkitDevices], list[PetKitBinarySensorDesc]] =
             only_for_types=[W7H],
         ),
         PetKitBinarySensorDesc(
-            key="Water tank storage full",
-            translation_key="stg_full_state",
+            key="Recirculation tray low",
+            translation_key="recirculation_tray_low",
             device_class=BinarySensorDeviceClass.PROBLEM,
-            value=lambda device: device.state.stg_full_state,
+            value=lambda device: device.state.stg_full_state == 0,
             only_for_types=[W7H],
         ),
         PetKitBinarySensorDesc(

--- a/custom_components/petkit/camera.py
+++ b/custom_components/petkit/camera.py
@@ -17,11 +17,13 @@ from go2rtc_client.ws import (
 )
 from pypetkitapi import (
     FEEDER_WITH_CAMERA,
+    FOUNTAIN_WITH_CAMERA,
     LITTER_WITH_CAMERA,
     Feeder,
     Litter,
     LiveFeed,
     MediaType,
+    WaterFountain,
 )
 from webrtc_models import RTCIceCandidateInit, RTCIceServer
 
@@ -71,7 +73,7 @@ class _BrowserSession:
     queued_candidates: list[str] = field(default_factory=list)
 
 
-CAMERA_MAPPING: dict[type[Feeder | Litter], list[PetKitCameraDesc]] = {
+CAMERA_MAPPING: dict[type[Feeder | Litter | WaterFountain], list[PetKitCameraDesc]] = {
     Feeder: [
         PetKitCameraDesc(
             key="camera",
@@ -85,6 +87,14 @@ CAMERA_MAPPING: dict[type[Feeder | Litter], list[PetKitCameraDesc]] = {
             key="camera",
             translation_key="camera",
             only_for_types=LITTER_WITH_CAMERA,
+            value=lambda _device: True,
+        )
+    ],
+    WaterFountain: [
+        PetKitCameraDesc(
+            key="camera",
+            translation_key="camera",
+            only_for_types=FOUNTAIN_WITH_CAMERA,
             value=lambda _device: True,
         )
     ],
@@ -136,7 +146,7 @@ class PetkitWebRTCCamera(PetkitCameraBaseEntity):
     def __init__(
         self,
         coordinator: PetkitDataUpdateCoordinator,
-        device: Feeder | Litter,
+        device: Feeder | Litter | WaterFountain,
         entity_description: PetKitCameraDesc,
         hass: HomeAssistant,
     ) -> None:

--- a/custom_components/petkit/config_flow.py
+++ b/custom_components/petkit/config_flow.py
@@ -198,7 +198,7 @@ class PetkitOptionsFlowHandler(OptionsFlow):
 class PetkitFlowHandler(ConfigFlow, domain=DOMAIN):
     """Config flow for Petkit Smart Devices."""
 
-    VERSION = 9
+    VERSION = 10
 
     @staticmethod
     @callback

--- a/custom_components/petkit/config_flow.py
+++ b/custom_components/petkit/config_flow.py
@@ -198,7 +198,7 @@ class PetkitOptionsFlowHandler(OptionsFlow):
 class PetkitFlowHandler(ConfigFlow, domain=DOMAIN):
     """Config flow for Petkit Smart Devices."""
 
-    VERSION = 8
+    VERSION = 9
 
     @staticmethod
     @callback

--- a/custom_components/petkit/const.py
+++ b/custom_components/petkit/const.py
@@ -70,6 +70,7 @@ DEFAULT_EVENTS = [
     "Pet_detect",
     "Drink_over",
 ]
+FOUNTAIN_MEDIA_EVENTS = ["Pet_detect", "Drink_over"]
 DEFAULT_DL_VIDEO = False
 DEFAULT_DL_IMAGE = True
 DEFAULT_SMART_POLLING = True

--- a/custom_components/petkit/entity.py
+++ b/custom_components/petkit/entity.py
@@ -195,7 +195,7 @@ class PetkitCameraBaseEntity(
     def __init__(
         self,
         coordinator: PetkitDataUpdateCoordinator,
-        device: Feeder | Litter,
+        device: Feeder | Litter | WaterFountain,
         key: str,
     ) -> None:
         """Initialize the camera entity."""

--- a/custom_components/petkit/icons.json
+++ b/custom_components/petkit/icons.json
@@ -252,6 +252,12 @@
       },
       "waste_check": {
         "default": "mdi:camera"
+      },
+      "last_pet_detect_event": {
+        "default": "mdi:camera"
+      },
+      "last_drink_event": {
+        "default": "mdi:camera"
       }
     },
     "light": {

--- a/custom_components/petkit/icons.json
+++ b/custom_components/petkit/icons.json
@@ -238,10 +238,16 @@
       "dish_before": {
         "default": "mdi:camera"
       },
+      "last_drink_event": {
+        "default": "mdi:camera"
+      },
       "last_eat_event": {
         "default": "mdi:camera"
       },
       "last_feed_event": {
+        "default": "mdi:camera"
+      },
+      "last_pet_detect_event": {
         "default": "mdi:camera"
       },
       "last_toileting_event": {
@@ -251,12 +257,6 @@
         "default": "mdi:camera"
       },
       "waste_check": {
-        "default": "mdi:camera"
-      },
-      "last_pet_detect_event": {
-        "default": "mdi:camera"
-      },
-      "last_drink_event": {
         "default": "mdi:camera"
       }
     },

--- a/custom_components/petkit/icons.json
+++ b/custom_components/petkit/icons.json
@@ -140,6 +140,13 @@
           "on": "mdi:power"
         }
       },
+      "recirculation_tray_low": {
+        "default": "mdi:water-outline",
+        "state": {
+          "off": "mdi:water-check",
+          "on": "mdi:water-alert"
+        }
+      },
       "replace_filter": {
         "default": "mdi:air-filter",
         "state": {
@@ -335,6 +342,15 @@
         "state": {
           "0": "mdi:battery-low",
           "1": "mdi:battery-high"
+        }
+      },
+      "clean_water_tank_state": {
+        "default": "mdi:water-outline",
+        "state": {
+          "empty": "mdi:water-remove",
+          "low": "mdi:water-alert",
+          "normal": "mdi:water-check",
+          "unknown": "mdi:water-off"
         }
       },
       "desiccant_left_days": {

--- a/custom_components/petkit/image.py
+++ b/custom_components/petkit/image.py
@@ -100,15 +100,15 @@ IMAGE_MAPPING: dict[type[PetkitDevices], list[PetKitImageDesc]] = {
     WaterFountain: [
         *COMMON_ENTITIES,
         PetKitImageDesc(
-            key="Pet detect",
+            key="Last pet detect event",
             event_key="pet_detect",
-            translation_key="pet_detect",
+            translation_key="last_pet_detect_event",
             only_for_types=FOUNTAIN_WITH_CAMERA,
         ),
         PetKitImageDesc(
-            key="Drink",
+            key="Last drink event",
             event_key="drink_over",
-            translation_key="drink_over",
+            translation_key="last_drink_event",
             only_for_types=FOUNTAIN_WITH_CAMERA,
         ),
     ],
@@ -155,6 +155,7 @@ class PetkitImage(PetkitEntity, ImageEntity):
         ImageEntity.__init__(self, coordinator.hass)
         self.coordinator = coordinator
         self.entity_description = entity_description
+        self._attr_translation_key = entity_description.translation_key
         self.config_entry = config_entry
         self.device = device
         self.media_list = []

--- a/custom_components/petkit/sensor.py
+++ b/custom_components/petkit/sensor.py
@@ -562,8 +562,10 @@ SENSOR_MAPPING: dict[type[PetkitDevices], list[PetKitSensorDesc]] = {
             entity_category=EntityCategory.DIAGNOSTIC,
             device_class=SensorDeviceClass.ENERGY,
             native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-            value=lambda device: round(
-                ((0.75 * int(device.today_pump_run_time)) / 3600000), 4
+            value=lambda device: (
+                None
+                if device.today_pump_run_time is None
+                else round(((0.75 * int(device.today_pump_run_time)) / 3600000), 4)
             ),
         ),
         PetKitSensorDesc(
@@ -587,8 +589,10 @@ SENSOR_MAPPING: dict[type[PetkitDevices], list[PetKitSensorDesc]] = {
             translation_key="purified_water",
             entity_category=EntityCategory.DIAGNOSTIC,
             state_class=SensorStateClass.MEASUREMENT,
-            value=lambda device: int(
-                ((1.5 * int(device.today_pump_run_time)) / 60) / 3.0
+            value=lambda device: (
+                None
+                if device.today_pump_run_time is None
+                else int(((1.5 * int(device.today_pump_run_time)) / 60) / 3.0)
             ),
             only_for_types=[CTW3],
         ),
@@ -597,8 +601,10 @@ SENSOR_MAPPING: dict[type[PetkitDevices], list[PetKitSensorDesc]] = {
             translation_key="purified_water",
             entity_category=EntityCategory.DIAGNOSTIC,
             state_class=SensorStateClass.MEASUREMENT,
-            value=lambda device: int(
-                ((1.5 * int(device.today_pump_run_time)) / 60) / 2.0
+            value=lambda device: (
+                None
+                if device.today_pump_run_time is None
+                else int(((1.5 * int(device.today_pump_run_time)) / 60) / 2.0)
             ),
             ignore_types=[CTW3],
         ),

--- a/custom_components/petkit/sensor.py
+++ b/custom_components/petkit/sensor.py
@@ -670,6 +670,19 @@ SENSOR_MAPPING: dict[type[PetkitDevices], list[PetKitSensorDesc]] = {
             only_for_types=[W7H],
         ),
         PetKitSensorDesc(
+            key="Clean water tank state",
+            translation_key="clean_water_tank_state",
+            entity_category=EntityCategory.DIAGNOSTIC,
+            device_class=SensorDeviceClass.ENUM,
+            options=["normal", "empty", "low", "unknown"],
+            value=lambda device: {
+                0: "normal",
+                2: "empty",
+                3: "low",
+            }.get(device.state.cwt_state, "unknown"),
+            only_for_types=[W7H],
+        ),
+        PetKitSensorDesc(
             key="Drink count",
             translation_key="drink_count",
             state_class=SensorStateClass.TOTAL_INCREASING,

--- a/custom_components/petkit/translations/en.json
+++ b/custom_components/petkit/translations/en.json
@@ -75,6 +75,9 @@
       "clean_water_tank_installed": {
         "name": "Clean water tank installed"
       },
+      "recirculation_tray_low": {
+        "name": "Recirculation tray low"
+      },
       "flush_state": {
         "name": "Flushing"
       },
@@ -374,6 +377,15 @@
       },
       "heater_real_temp": {
         "name": "Heater temperature"
+      },
+      "clean_water_tank_state": {
+        "name": "Clean water tank state",
+        "state": {
+          "normal": "Normal",
+          "empty": "Empty",
+          "low": "Low",
+          "unknown": "Unknown"
+        }
       },
       "drink_count": {
         "name": "Drink count"

--- a/custom_components/petkit/translations/en.json
+++ b/custom_components/petkit/translations/en.json
@@ -291,10 +291,10 @@
       "waste_check": {
         "name": "Waste check"
       },
-      "pet_detect": {
-        "name": "Pet detected"
+      "last_pet_detect_event": {
+        "name": "Last pet detect event"
       },
-      "drink_over": {
+      "last_drink_event": {
         "name": "Last drink event"
       }
     },


### PR DESCRIPTION
## Summary

Collaboration PR for **Petkit EverSweet Ultra AI (W7H)** — incremental changes on top of upstream `feat/add-support-eversweetultra`.

**Intent:** iterate together until debugging and rework is complete. Maintainer edits welcome on `ekobres:feat/add-support-eversweetultra`.

### This PR adds (2 commits on top of upstream feature branch)

- W7H fixes on top of upstream eversweet ultra support
- Config-entry v10 migration to include fountain media event types (`Pet_detect`, `Drink_over`)

## Test plan

- [ ] Verify new fixes and config migration on existing installs
- [ ] Confirm media downloads for fountain events after migration
- [ ] Run pre-commit / CI checks

## Notes

- Water-level sensor semantics (STG vs CWT) under investigation on hardware.
- Opened **ready for review** - merge is okay at any time - I can open new PRs for additional work.