### PR TITLE
fix: restore_state entities silently not created when value is momentarily None

### DIFF
--- a/custom_components/petkit/entity.py
+++ b/custom_components/petkit/entity.py
@@ -89,6 +89,15 @@ class PetKitDescSensorBase(EntityDescription):
         if self._is_not_in_supported_types(device_type):
             return False
 
+        if getattr(self, "restore_state", False):
+            # Entities that restore their last known state must always be
+            # created, even if the current value is momentarily unavailable
+            # (e.g. right after a HA restart, before the coordinator has a
+            # meaningful reading). Otherwise RestoreSensor never gets a
+            # chance to run and the entity is silently dropped for the
+            # whole session.
+            return True
+
         return self._check_value_support(device)
 
     def _is_force_added(self, device_type: str) -> bool:


### PR DESCRIPTION
## Summary

Fixes #251.

`pet_last_use_duration` (reported in #251) and `pet_last_weight_measurement` are siblings under the `Pet: [...]` list in `sensor.py`, both declared with `restore_state=True`. Both go through `PetKitDescSensorBase.is_supported()` in `entity.py`, which calls the description's `value()` lambda **before the entity is even created**:

```python
def _check_value_support(self, device):
    if self.value is not None:
        result = self.value(device)
        if result is None:
            return False   # entity is never instantiated this HA session
```

If, at the exact moment platforms are set up (e.g. right after a container/HA restart), the underlying coordinator value is momentarily `None`/falsy, the entity is **never created** for that HA session — not "unavailable", it simply doesn't exist.

This makes `restore_state=True` / `RestoreSensor` useless in that scenario: `async_added_to_hass()`, which restores the last known value, only runs on an entity HA actually instantiated. If `is_supported()` filtered it out first, there is nothing to restore into, so the entity silently disappears until the integration is reloaded (by which point the coordinator has fresher data and the lambda no longer returns `None`).

This is consistent with the `pet_last_weight_measurement` "reports 0.0" fix in a1e8108, which patched the `value == 0` case but left the underlying design issue in place.

## Change

In `PetKitDescSensorBase.is_supported()`, skip the value-based existence check when the description declares `restore_state=True`: those entities are always created (once the usual force_add/ignore/only_for_types filters pass), and `RestoreSensor` is left to handle the "no live data yet" case as it was designed to.

## Test plan

- [ ] Confirm `pet_last_use_duration` and `pet_last_weight_measurement` entities are created and keep their last known value across a HA restart, even when the litter box has no fresh event at startup
- [ ] Confirm entities with `restore_state` unset are unaffected (still gated on `value()` as before)