### PR TITLE
Per-pet feeder sensors

### DIFF
--- a/custom_components/petkit/sensor.py
+++ b/custom_components/petkit/sensor.py
@@ -858,6 +858,42 @@ SENSOR_MAPPING: dict[type[PetkitDevices], list[PetKitSensorDesc]] = {
             value=lambda pet: format_pet_date(pet.last_defecation),
             restore_state=True,
         ),
+        PetKitSensorDesc(
+            key="Pet last meal date",
+            translation_key="pet_last_meal_date",
+            entity_picture=lambda pet: pet.avatar,
+            value=lambda pet: (
+                datetime.fromtimestamp(pet.last_meal_time)
+                if pet.last_meal_time is not None and pet.last_meal_time != 0
+                else "Unknown"
+            ),
+            restore_state=True,
+        ),
+        PetKitSensorDesc(
+            key="Pet last meal duration",
+            translation_key="pet_last_meal_duration",
+            entity_picture=lambda pet: pet.avatar,
+            device_class=SensorDeviceClass.DURATION,
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=UnitOfTime.SECONDS,
+            value=lambda pet: pet.last_meal_duration or None,
+            restore_state=True,
+        ),
+        PetKitSensorDesc(
+            key="Pet last feeder used",
+            translation_key="pet_last_feeder_used",
+            entity_picture=lambda pet: pet.avatar,
+            value=lambda pet: pet.last_feeder_used,
+            restore_state=True,
+        ),
+        PetKitSensorDesc(
+            key="Pet meals today",
+            translation_key="pet_meals_today",
+            entity_picture=lambda pet: pet.avatar,
+            state_class=SensorStateClass.TOTAL,
+            value=lambda pet: pet.meals_today,
+            restore_state=True,
+        ),
     ],
 }
 

--- a/custom_components/petkit/translations/en.json
+++ b/custom_components/petkit/translations/en.json
@@ -692,6 +692,18 @@
       },
       "sand_tray_left_days": {
         "name": "Sand tray left days"
+      },
+      "pet_last_meal_date": {
+        "name": "Last meal date"
+      },
+      "pet_last_meal_duration": {
+        "name": "Last meal duration"
+      },
+      "pet_last_feeder_used": {
+        "name": "Last feeder used"
+      },
+      "pet_meals_today": {
+        "name": "Meals today"
       }
     },
     "switch": {


### PR DESCRIPTION
## Problem

Every per-pet sensor today is sourced from litter box stats, so a household with a recognising feeder and no litter box sees nothing on the Pet devices — even though PetKit attributes each meal to a pet and the integration already receives that attribution on every poll.

## Change

Four sensors on the Pet device — last meal date, last meal duration, last feeder used, meals today — reading the `Pet` fields populated by `populate_pet_feeder_stats()`, exactly as the existing sensors read `last_litter_usage`, `last_duration_usage` and `last_device_used`.

Plus the `en.json` strings.

## Depends on

Jezza34000/py-petkit-api#99, which adds the `Pet` fields and the populate step. The `manifest.json` pin needs bumping to whichever `pypetkitapi` release carries it before this merges — happy to push that commit once you have cut the release, or to do it now if you would rather pin a pre-release.

## Context

Built against a live D4SH-2 with three recognised cats. Library side is unit tested against a trimmed real payload; on this side I ran the equivalent logic as a standalone custom component against the same account for a day before writing these descriptions, which is where the field choices come from — a bare "last meal" timestamp turns out not to be very useful without the count and the meal length next to it.