### PR TITLE
Pet weight: keep the decimal when writing to the API

### DIFF
--- a/custom_components/petkit/number.py
+++ b/custom_components/petkit/number.py
@@ -235,7 +235,9 @@ NUMBER_MAPPING: dict[type[PetkitDevices], list[PetKitNumberDesc]] = {
             mode=NumberMode.BOX,
             native_value=lambda device: device.pet_details.weight,
             action=lambda api, device, value: api.send_api_request(
-                device.id, PetCommand.PET_UPDATE_SETTING, {"weight": round(float(value), 1)}
+                device.id,
+                PetCommand.PET_UPDATE_SETTING,
+                {"weight": round(float(value), 1)},
             ),
             only_for_types=[PET],
         ),

--- a/custom_components/petkit/number.py
+++ b/custom_components/petkit/number.py
@@ -235,7 +235,7 @@ NUMBER_MAPPING: dict[type[PetkitDevices], list[PetKitNumberDesc]] = {
             mode=NumberMode.BOX,
             native_value=lambda device: device.pet_details.weight,
             action=lambda api, device, value: api.send_api_request(
-                device.id, PetCommand.PET_UPDATE_SETTING, {"weight": int(value)}
+                device.id, PetCommand.PET_UPDATE_SETTING, {"weight": round(float(value), 1)}
             ),
             only_for_types=[PET],
         ),


### PR DESCRIPTION
### Problem

`number.<pet>_peso` cannot be set to a fractional weight. The descriptor declares
`native_step=0.1`, but the write casts to `int`:

https://github.com/Jezza34000/homeassistant_petkit/blob/main/custom_components/petkit/number.py#L238

```python
native_step=0.1,
...
action=lambda api, device, value: api.send_api_request(
    device.id, PetCommand.PET_UPDATE_SETTING, {"weight": int(value)}
),
```

So setting 3.2 kg sends `{"weight": 3}`, the entity reads back its old value, and
it looks to the user as if the write silently failed. For a 3-4 kg cat that is a
5-15% error, and 0.1 kg is exactly the resolution a weight trend needs to be
useful. Present on `main` and in 1.25.0 - 1.27.0.

### Fix

Round to one decimal, matching `native_step`, instead of truncating.

### Verification

Against `api.eu-pet.com/latest/pet/updatepetprops` with a real account on 1.27.0,
the API accepts a float and echoes it back:

```
DEBUG [pypetkitapi.client] Control API device=pet id=101401316
      action=pet_update_setting param={'weight': 3.2}
DEBUG [pypetkitapi.client] Command execution success, API response :
      {'id': '101401316', 'name': 'Tea', ..., 'weight': 3.2,
       'weightLabel': 'Normal', 'updatedAt': '2026-07-28T22:32:20.000+0000'}
```

Confirmed in the PetKit app afterwards (7.1 lb with the app set to imperial,
= 3.2 kg). Three cats set to 3.3 / 3.2 / 4.3 kg, all correct.

### Separate issue found while verifying, not addressed here

Worth a look independently: after a successful write the value does **not** appear
in Home Assistant. Every subsequent coordinator refresh kept reporting the old
weight from the account/family listing, even minutes later and after
`homeassistant.update_entity`, while the pet record server-side had already been
updated. Only reloading the config entry (a fresh login) surfaced the new value.

The pet data appears to come from the account listing rather than a pet-detail
read, and that listing seems to be served stale after `updatepetprops`. Happy to
open a separate issue with logs if useful.
