### PR TITLE
fix: make device_status and battery_level states translatable

### DIFF
--- a/custom_components/petkit/const.py
+++ b/custom_components/petkit/const.py
@@ -97,16 +97,23 @@ NO_ERROR = "No error"
 # Status mapping
 POWER_ONLINE_STATE = [1, 2]
 
+# Values are translation keys, not display strings: Home Assistant only applies
+# `state` translations to sensors declared with SensorDeviceClass.ENUM, so these
+# must match the keys under entity.sensor.<translation_key>.state in strings.json.
 DEVICE_STATUS_MAP = {
-    0: "Offline",
-    1: "Online",
-    2: "On battery",
+    0: "offline",
+    1: "online",
+    2: "on_battery",
 }
 
+DEVICE_STATUS_OPTIONS = ["offline", "online", "on_battery", "unknown"]
+
 BATTERY_LEVEL_MAP = {
-    "0": "Low",
-    "1": "Normal",
+    "0": "low",
+    "1": "normal",
 }
+
+BATTERY_LEVEL_OPTIONS = ["low", "normal", "not_in_use", "unknown"]
 
 # Text input regex
 INPUT_FEED_PATTERN = "^(0|[1-9][0-9]?|[1-3][0-9]{2}|400)$"

--- a/custom_components/petkit/sensor.py
+++ b/custom_components/petkit/sensor.py
@@ -51,7 +51,15 @@ from homeassistant.const import (
     UnitOfVolume,
 )
 
-from .const import BATTERY_LEVEL_MAP, DEVICE_STATUS_MAP, DOMAIN, LOGGER, NO_ERROR
+from .const import (
+    BATTERY_LEVEL_MAP,
+    BATTERY_LEVEL_OPTIONS,
+    DEVICE_STATUS_MAP,
+    DEVICE_STATUS_OPTIONS,
+    DOMAIN,
+    LOGGER,
+    NO_ERROR,
+)
 from .entity import PetKitDescSensorBase, PetkitEntity
 from .utils import (
     get_raw_feed_plan_from_schedule,
@@ -122,7 +130,9 @@ COMMON_ENTITIES = [
         key="Device status",
         translation_key="device_status",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value=lambda device: DEVICE_STATUS_MAP.get(device.state.pim, "Unknown Status"),
+        device_class=SensorDeviceClass.ENUM,
+        options=DEVICE_STATUS_OPTIONS,
+        value=lambda device: DEVICE_STATUS_MAP.get(device.state.pim, "unknown"),
     ),
     PetKitSensorDesc(
         key="Rssi",
@@ -181,10 +191,12 @@ SENSOR_MAPPING: dict[type[PetkitDevices], list[PetKitSensorDesc]] = {
             key="Battery level",
             translation_key="battery_level",
             entity_category=EntityCategory.DIAGNOSTIC,
+            device_class=SensorDeviceClass.ENUM,
+            options=BATTERY_LEVEL_OPTIONS,
             value=lambda device: (
-                BATTERY_LEVEL_MAP.get(device.state.battery_status, "Unknown")
+                BATTERY_LEVEL_MAP.get(device.state.battery_status, "unknown")
                 if device.state.pim == 2
-                else "Not in use"
+                else "not_in_use"
             ),
         ),
         PetKitSensorDesc(

--- a/custom_components/petkit/translations/de.json
+++ b/custom_components/petkit/translations/de.json
@@ -211,7 +211,13 @@
         "name": "Durchschnittliche Fresszeit"
       },
       "battery_level": {
-        "name": "Batteriestand"
+        "name": "Batteriestand",
+        "state": {
+          "low": "Niedrig",
+          "normal": "Normal",
+          "not_in_use": "Nicht in Gebrauch",
+          "unknown": "Unbekannt"
+        }
       },
       "deodorant_left_days": {
         "name": "Verbleibende Tage Desodorierer"
@@ -223,7 +229,13 @@
         "name": "Verbleibende Tage Trockenmittel"
       },
       "device_status": {
-        "name": "Ger\u00e4testatus"
+        "name": "Ger\u00e4testatus",
+        "state": {
+          "offline": "Offline",
+          "online": "Online",
+          "on_battery": "Im Batteriebetrieb",
+          "unknown": "Unbekannt"
+        }
       },
       "drink_times": {
         "name": "Trinkzeiten"

--- a/custom_components/petkit/translations/en.json
+++ b/custom_components/petkit/translations/en.json
@@ -430,7 +430,13 @@
         "name": "Average eating time"
       },
       "battery_level": {
-        "name": "Battery level"
+        "name": "Battery level",
+        "state": {
+          "low": "Low",
+          "normal": "Normal",
+          "not_in_use": "Not in use",
+          "unknown": "Unknown"
+        }
       },
       "odor_eliminator_n50_left_days": {
         "name": "Odor eliminator N50 left days"
@@ -445,7 +451,13 @@
         "name": "Desiccant left days"
       },
       "device_status": {
-        "name": "Device status"
+        "name": "Device status",
+        "state": {
+          "offline": "Offline",
+          "online": "Online",
+          "on_battery": "On battery",
+          "unknown": "Unknown"
+        }
       },
       "drink_times": {
         "name": "Drink times"

--- a/custom_components/petkit/translations/fr.json
+++ b/custom_components/petkit/translations/fr.json
@@ -325,7 +325,13 @@
         "name": "Temps de repas moyen"
       },
       "battery_level": {
-        "name": "Niveau de la batterie"
+        "name": "Niveau de la batterie",
+        "state": {
+          "low": "Faible",
+          "normal": "Normal",
+          "not_in_use": "Non utilisé",
+          "unknown": "Inconnu"
+        }
       },
       "odor_eliminator_n50_left_days": {
         "name": "Jours restants éliminateur d'odeurs N50"
@@ -340,7 +346,13 @@
         "name": "Jours restants déshydratant"
       },
       "device_status": {
-        "name": "État de l'appareil"
+        "name": "État de l'appareil",
+        "state": {
+          "offline": "Hors ligne",
+          "online": "En ligne",
+          "on_battery": "Sur batterie",
+          "unknown": "Inconnu"
+        }
       },
       "drink_times": {
         "name": "Nombre de fois qu'il a bu"

--- a/custom_components/petkit/translations/it.json
+++ b/custom_components/petkit/translations/it.json
@@ -200,7 +200,13 @@
         "name": "Tempo medio pasto"
       },
       "battery_level": {
-        "name": "Livello batteria"
+        "name": "Livello batteria",
+        "state": {
+          "low": "Basso",
+          "normal": "Normale",
+          "not_in_use": "Non in uso",
+          "unknown": "Sconosciuto"
+        }
       },
       "deodorant_left_days": {
         "name": "Giorni rimanenti deodorante"
@@ -212,7 +218,13 @@
         "name": "Giorni rimanenti essicante"
       },
       "device_status": {
-        "name": "Stato dispositivo"
+        "name": "Stato dispositivo",
+        "state": {
+          "offline": "Non in linea",
+          "online": "In linea",
+          "on_battery": "A batteria",
+          "unknown": "Sconosciuto"
+        }
       },
       "drink_times": {
         "name": "Volte bevuto"


### PR DESCRIPTION
`device_status` and `battery_level` have a `translation_key` but return English display strings with no `device_class`, so their states are never translated. `device_status` is on every device.

Converts both to enums (same pattern as the food-level sensor), plus en/it/fr/de state translations. Breaking: `Online` → `online`, `Not in use` → `not_in_use`.

Left `error_message` alone — its error state is free-form vendor text, so it can't be enumerated. Could add a separate `error_state` enum sensor if you want.
