### PR TITLE
fix: make a stalled coordinator refresh visible instead of silent

### DIFF
--- a/custom_components/petkit/const.py
+++ b/custom_components/petkit/const.py
@@ -91,6 +91,16 @@ MEDIA_ROOT = "/media/local"
 SCAN_INTERVAL_FAST = 5
 SCAN_INTERVAL_SLOW = 190
 
+# Hard ceiling on a single coordinator refresh, in seconds.
+#
+# Chosen so it cannot fire on a merely slow-but-healthy poll: a healthy refresh has
+# to finish inside DEFAULT_SCAN_INTERVAL (60s) for polling to keep up at all, and
+# Home Assistant already warns when a refresh overruns its update interval. 120s is
+# twice that, so reaching it means something pathological rather than slow. It also
+# sits below SCAN_INTERVAL_SLOW (190s), so even in the slowest polling mode a stalled
+# refresh surfaces before the next scheduled one and at most one interval is lost.
+COORDINATOR_REFRESH_TIMEOUT = 120
+
 # Messages constants
 NO_ERROR = "No error"
 

--- a/custom_components/petkit/coordinator.py
+++ b/custom_components/petkit/coordinator.py
@@ -40,6 +40,7 @@ from .const import (
     CONF_MEDIA_DL_VIDEO,
     CONF_MEDIA_EV_TYPE,
     CONF_MEDIA_PATH,
+    COORDINATOR_REFRESH_TIMEOUT,
     DEFAULT_BLUETOOTH_RELAY,
     DEFAULT_DELETE_AFTER,
     DEFAULT_DL_IMAGE,
@@ -110,10 +111,15 @@ class PetkitDataUpdateCoordinator(DataUpdateCoordinator):
         self,
     ) -> dict[int, Feeder | Litter | WaterFountain | Purifier | Pet]:
         """Update data via library."""
-        await self._update_smart_polling()
-
         try:
-            await self.config_entry.runtime_data.client.get_devices_data()
+            # The timeout is what makes a stalled refresh VISIBLE. Without it a
+            # request that never returns raises nothing, so last_update_success
+            # keeps its previous True, entities keep their last values and the
+            # config entry stays state=loaded / reason=None - the integration
+            # reports healthy while it has silently stopped updating.
+            async with asyncio.timeout(COORDINATOR_REFRESH_TIMEOUT):
+                await self._update_smart_polling()
+                await self.config_entry.runtime_data.client.get_devices_data()
         except (
             PetkitSessionExpiredError,
             PetkitSessionError,
@@ -121,6 +127,11 @@ class PetkitDataUpdateCoordinator(DataUpdateCoordinator):
             PetkitRegionalServerNotFoundError,
         ) as exception:
             raise ConfigEntryAuthFailed(exception) from exception
+        except TimeoutError as exception:
+            raise UpdateFailed(
+                f"Timeout of {COORDINATOR_REFRESH_TIMEOUT}s exceeded while refreshing "
+                "PetKit data; the previous refresh never completed"
+            ) from exception
         except PypetkitError as exception:
             raise UpdateFailed(exception) from exception
         else:


### PR DESCRIPTION
A hang in `_async_update_data` raises nothing, so `last_update_success` stays `True` and entities go stale rather than `unavailable`. Hit it on a live install: ~22h frozen, only a manual reload fixed it.

Adds `asyncio.timeout` so a stall becomes `UpdateFailed`, and moves `_update_smart_polling()` inside the `try` — it was outside, so anything it raised skipped error handling.

120s = 2× `DEFAULT_SCAN_INTERVAL`, under `SCAN_INTERVAL_SLOW`.

<details>
<summary>Evidence — recorder history across the freeze</summary>

Integration 1.27.0, HA 2026.7.4. The install runs Italian, so `sensor.yumshare_dual_hopper_2_riempimento_ciotola` is `food_bowl_percentage` upstream.

```
curl -s -H "Authorization: Bearer $HA_TOKEN" \
  'http://homeassistant:8123/api/history/period/2026-08-15T20:55:00%2B00:00?end_time=2026-08-16T18:55:00%2B00:00&filter_entity_id=sensor.yumshare_dual_hopper_2_riempimento_ciotola&minimal_response'
```

```json
[
    [
        {
            "entity_id": "sensor.yumshare_dual_hopper_2_riempimento_ciotola",
            "state": "0",
            "attributes": {
                "state_class": "measurement",
                "unit_of_measurement": "%",
                "friendly_name": "YUMSHARE DUAL-HOPPER 2 Riempimento ciotola"
            },
            "last_changed": "2026-08-15T20:55:00+00:00",
            "last_updated": "2026-08-15T20:55:00+00:00"
        },
        {
            "state": "34",
            "last_changed": "2026-08-15T21:01:22.370492+00:00"
        },
        {
            "state": "0",
            "last_changed": "2026-08-15T21:02:17.213316+00:00"
        },
        {
            "state": "unavailable",
            "last_changed": "2026-08-16T18:50:33.626081+00:00"
        },
        {
            "state": "34",
            "last_changed": "2026-08-16T18:50:45.251120+00:00"
        },
        {
            "state": "36",
            "last_changed": "2026-08-16T18:50:47.428160+00:00"
        },
        {
            "state": "0",
            "last_changed": "2026-08-16T18:51:51.034487+00:00"
        }
    ]
]
```

21:02:17 to 18:50:33 is 21.8h with no write. The entity never went `unavailable` during it — the `unavailable` at 18:50:33 is the manual config-entry reload, and values resume 12s later.

</details>
